### PR TITLE
allow passing in an arbitrary reva config map

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,8 @@ type Reva struct {
 	HTTP      HTTP
 	GRPC      GRPC
 	JWTSecret string
+	// Used to pass in configs from the ocis repo, multiple reva instances can be started with this
+	Configs map[string]interface{}
 }
 
 // AuthProvider defines the available authprovider configuration.


### PR DESCRIPTION
We want to start only the the oidcprovider for `ocis demo`. This allows passing in arbitrary reva configurations and starting them in parallel.