### PR TITLE
change default ocdav namespace

### DIFF
--- a/changelog/unreleased/change-default-namespace.md
+++ b/changelog/unreleased/change-default-namespace.md
@@ -1,0 +1,9 @@
+Change: use /home as default namespace
+
+Currently, cross storage etag propagation is not yet implemented, which prevents the desktop client from detecting changes via the PROPFIND to /. / is managed by the root storage provider which is independend of the home and oc storage providers. If a file changes in /home/foo, the etag change will only be propagated to the root of the home storage provider.
+
+This change jails users into the `/home` namespace, and allows configuring the namespace to use for the two webdav endpoints using the new environment variable `WEBDAV_NAMESPACE_JAIL` which affects both endpoints `/dav/files` and `/webdav`.
+
+This will allow us to focus on getting a single storage driver like eos or owncloud tested and better resembles what owncloud 10 does.
+
+To get back the global namespace, which ultimately is the goal, just set the above environment variable to `/`.

--- a/pkg/command/frontend.go
+++ b/pkg/command/frontend.go
@@ -187,8 +187,8 @@ func Frontend(cfg *config.Config) *cli.Command {
 								"prefix":           "",
 								"chunk_folder":     "/var/tmp/revad/chunks",
 								"gateway":          cfg.Reva.Gateway.URL,
-								"files_namespace":  "/",
-								"webdav_namespace": "/",
+								"files_namespace":  cfg.Reva.OCDav.NamespaceJail,
+								"webdav_namespace": cfg.Reva.OCDav.NamespaceJail,
 							},
 							"ocs": map[string]interface{}{
 								"gateway": cfg.Reva.Gateway.URL,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,11 @@ type LDAPSchema struct {
 	CN          string
 }
 
+// OCDav defines the available ocdav configuration.
+type OCDav struct {
+	NamespaceJail string
+}
+
 // Reva defines the available reva configuration.
 type Reva struct {
 	// JWTSecret used to sign jwt tokens between services
@@ -186,6 +191,7 @@ type Reva struct {
 	TransferExpires int
 	OIDC            OIDC
 	LDAP            LDAP
+	OCDav           OCDav
 	Storages        StorageConfig
 	// Ports are used configure which services to start on which port
 	Frontend          Port

--- a/pkg/flagset/frontend.go
+++ b/pkg/flagset/frontend.go
@@ -89,6 +89,16 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.Reva.TransferSecret,
 		},
 
+		// OCDav
+
+		&cli.StringFlag{
+			Name:        "webdav-namespace-jail",
+			Value:       "/home/",
+			Usage:       "Namespace prefix for the webdav endpoints /dav/files and /webdav",
+			EnvVars:     []string{"WEBDAV_NAMESPACE_JAIL"},
+			Destination: &cfg.Reva.OCDav.NamespaceJail,
+		},
+
 		// OIDC
 
 		&cli.StringFlag{


### PR DESCRIPTION
Currently, cross storage etag propagation is not yet implemented, which prevents the desktop client from detecting changes via the PROPFIND to /. / is managed by the root storage provider which is independend of the home and oc storage providers. If a file changes in /home/foo, the etag change will only be propagated to the root of the home storage provider.

This change jails users into the `/home` namespace, and allows configuring the namespace to use for the two webdav endpoints using the new environment variable `WEBDAV_NAMESPACE_JAIL` which affects both endpoints `/dav/files` and `/webdav`.

This will allow us to focus on getting a single storage driver like eos or owncloud tested and better resembles what owncloud 10 does.

To get back the global namespace, which ultimately is the goal, just set the above environment variable to `/`.