### PR TITLE
allow different namespaces

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -140,7 +140,6 @@ def testing(ctx):
           'REVA_STORAGE_LOCAL_ROOT': '/srv/app/tmp/reva/root',
           'REVA_STORAGE_OWNCLOUD_DATADIR': '/srv/app/tmp/reva/data',
           'REVA_STORAGE_OC_DATA_TEMP_FOLDER': '/srv/app/tmp/',
-          'WEBDAV_NAMESPACE_JAIL': '/'
         },
         'commands': [
           'mkdir -p /srv/app/tmp/reva',

--- a/changelog/unreleased/pull-77.md
+++ b/changelog/unreleased/pull-77.md
@@ -1,0 +1,16 @@
+Bugfix: Allow different namespaces for /webdav and /dav/files
+
+After fbf131c the path for the "new" webdav path does not contain a username `/remote.php/dav/files/textfile0.txt`. It used to be `/remote.php/dav/files/oc/einstein/textfile0.txt` So it lost `oc/einstein`.
+
+This PR allows setting up different namespaces for `/webav` and `/dav/files`:
+
+`/webdav` is jailed into `/home` - which uses the home storage driver and uses the logged in user to construct the path
+`/dav/files` is jailed into `/oc` - which uses the owncloud storage driver and expects a username as the first path segment
+
+This mimics oc10
+
+The `WEBDAV_NAMESPACE_JAIL` environment variable is split into
+- `WEBDAV_NAMESPACE` and
+- `DAV_FILES_NAMESPACE` accordingly.
+
+Related: https://github.com/owncloud/ocis-reva/pull/68

--- a/pkg/command/frontend.go
+++ b/pkg/command/frontend.go
@@ -187,8 +187,8 @@ func Frontend(cfg *config.Config) *cli.Command {
 								"prefix":           "",
 								"chunk_folder":     "/var/tmp/revad/chunks",
 								"gateway":          cfg.Reva.Gateway.URL,
-								"files_namespace":  cfg.Reva.OCDav.NamespaceJail,
-								"webdav_namespace": cfg.Reva.OCDav.NamespaceJail,
+								"files_namespace":  cfg.Reva.OCDav.DavFilesNamespace,
+								"webdav_namespace": cfg.Reva.OCDav.WebdavNamespace,
 							},
 							"ocs": map[string]interface{}{
 								"gateway": cfg.Reva.Gateway.URL,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -180,7 +180,8 @@ type LDAPSchema struct {
 
 // OCDav defines the available ocdav configuration.
 type OCDav struct {
-	NamespaceJail string
+	WebdavNamespace   string
+	DavFilesNamespace string
 }
 
 // Reva defines the available reva configuration.

--- a/pkg/flagset/frontend.go
+++ b/pkg/flagset/frontend.go
@@ -92,11 +92,21 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 		// OCDav
 
 		&cli.StringFlag{
-			Name:        "webdav-namespace-jail",
+			Name:        "webdav-namespace",
 			Value:       "/home/",
-			Usage:       "Namespace prefix for the webdav endpoints /dav/files and /webdav",
-			EnvVars:     []string{"WEBDAV_NAMESPACE_JAIL"},
-			Destination: &cfg.Reva.OCDav.NamespaceJail,
+			Usage:       "Namespace prefix for the /webdav endpoint",
+			EnvVars:     []string{"WEBDAV_NAMESPACE"},
+			Destination: &cfg.Reva.OCDav.WebdavNamespace,
+		},
+
+		// the /dav/files endpoint expects a username as the first path segment
+		// this can eg. be set to /eos/users
+		&cli.StringFlag{
+			Name:        "dav-files-namespace",
+			Value:       "/oc/",
+			Usage:       "Namespace prefix for the webdav /dav/files endpoint",
+			EnvVars:     []string{"DAV_FILES_NAMESPACE"},
+			Destination: &cfg.Reva.OCDav.DavFilesNamespace,
 		},
 
 		// OIDC


### PR DESCRIPTION
after https://github.com/owncloud/ocis-reva/commit/fbf131c6b276f1b51e759666c450675e33d9e2db the path for the "new" webdav path does not contain a username /remote.php/dav/files/textfile0.txt it used to be /remote.php/dav/files/oc/einstein/textfile0.txt
So it lost oc/einstein

This PR allows setting up different namespaces for /webav and /dav/files:
 - /webdav is jailed into /home - which uses the home storage driver and uses the logged in user to construct the path
- /dav/files is jailed into /oc - which uses the owncloud storage driver and expects a username as the first path segment

this mimics oc10

related: https://github.com/owncloud/ocis-reva/pull/68

- [x] update CHANGELOG