### PR TITLE
Revert "set correct flag type (#76)"

### DIFF
--- a/changelog/unreleased/76
+++ b/changelog/unreleased/76
@@ -1,8 +1,0 @@
-Bugfix: set correct flag type in the flagsets
-
-While upgrading to the micro/cli version 2 there where two instances of `StringFlag`
-which had not been changed to `StringSliceFlag`.
-This caused `ocis-reva users` and `ocis-reva storage-root` to fail on startup.
-
-https://github.com/owncloud/ocis-reva/issues/75
-https://github.com/owncloud/ocis-reva/pull/76

--- a/pkg/flagset/storageroot.go
+++ b/pkg/flagset/storageroot.go
@@ -116,9 +116,9 @@ func StorageRootWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_STORAGE_ROOT_URL"},
 			Destination: &cfg.Reva.StorageRoot.URL,
 		},
-		&cli.StringSliceFlag{
+		&cli.StringFlag{
 			Name:    "service",
-			Value:   cli.NewStringSlice("storageprovider"),
+			Value:   "storageprovider",
 			Usage:   "--service storageprovider [--service otherservice]",
 			EnvVars: []string{"REVA_STORAGE_ROOT_SERVICES"},
 		},

--- a/pkg/flagset/users.go
+++ b/pkg/flagset/users.go
@@ -195,9 +195,9 @@ func UsersWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_USERS_URL"},
 			Destination: &cfg.Reva.Users.URL,
 		},
-		&cli.StringSliceFlag{
+		&cli.StringFlag{
 			Name:    "service",
-			Value:   cli.NewStringSlice("userprovider"), // TODO preferences
+			Value:   "userprovider", // TODO preferences
 			Usage:   "--service userprovider [--service otherservice]",
 			EnvVars: []string{"REVA_USERS_SERVICES"},
 		},


### PR DESCRIPTION
This reverts commit ac3381e2775c71a42816f3c2eeb64056455467d0.

Seems like that commit broke CI, without it its green again

