### PR TITLE
expose owncloud storage driver config in flagset

### DIFF
--- a/changelog/unreleased/issue-87.md
+++ b/changelog/unreleased/issue-87.md
@@ -1,0 +1,20 @@
+Enhancement: expose owncloud storage driver config in flagset
+
+Three new flags are now available:
+
+- scan files on startup to generate missing fileids
+  default: `true`
+  env var: `REVA_STORAGE_OWNCLOUD_SCAN`
+  cli option: `--storage-owncloud-scan`
+
+- autocreate home path for new users
+  default: `true`
+  env var: `REVA_STORAGE_OWNCLOUD_AUTOCREATE`
+  cli option: `--storage-owncloud-autocreate`
+
+- the address of the redis server
+  default: `:6379`
+  env var: `REVA_STORAGE_OWNCLOUD_REDIS_ADDR`
+  cli option: `--storage-owncloud-redis`
+
+https://github.com/owncloud/ocis-reva/issues/87

--- a/pkg/command/storagehome.go
+++ b/pkg/command/storagehome.go
@@ -113,6 +113,9 @@ func StorageHome(cfg *config.Config) *cli.Command {
 									},
 									"owncloud": map[string]interface{}{
 										"datadirectory": cfg.Reva.Storages.OwnCloud.Datadirectory,
+										"scan":          cfg.Reva.Storages.OwnCloud.Scan,
+										"autocreate":    cfg.Reva.Storages.OwnCloud.Autocreate,
+										"redis":         cfg.Reva.Storages.OwnCloud.Redis,
 									},
 									"s3": map[string]interface{}{
 										"region":     cfg.Reva.Storages.S3.Region,

--- a/pkg/command/storagehomedata.go
+++ b/pkg/command/storagehomedata.go
@@ -117,6 +117,9 @@ func StorageHomeData(cfg *config.Config) *cli.Command {
 									},
 									"owncloud": map[string]interface{}{
 										"datadirectory": cfg.Reva.Storages.OwnCloud.Datadirectory,
+										"scan":          cfg.Reva.Storages.OwnCloud.Scan,
+										"autocreate":    cfg.Reva.Storages.OwnCloud.Autocreate,
+										"redis":         cfg.Reva.Storages.OwnCloud.Redis,
 									},
 									"s3": map[string]interface{}{
 										"region":     cfg.Reva.Storages.S3.Region,

--- a/pkg/command/storageoc.go
+++ b/pkg/command/storageoc.go
@@ -113,6 +113,9 @@ func StorageOC(cfg *config.Config) *cli.Command {
 									},
 									"owncloud": map[string]interface{}{
 										"datadirectory": cfg.Reva.Storages.OwnCloud.Datadirectory,
+										"scan":          cfg.Reva.Storages.OwnCloud.Scan,
+										"autocreate":    cfg.Reva.Storages.OwnCloud.Autocreate,
+										"redis":         cfg.Reva.Storages.OwnCloud.Redis,
 									},
 									"s3": map[string]interface{}{
 										"region":     cfg.Reva.Storages.S3.Region,

--- a/pkg/command/storageocdata.go
+++ b/pkg/command/storageocdata.go
@@ -117,6 +117,9 @@ func StorageOCData(cfg *config.Config) *cli.Command {
 									},
 									"owncloud": map[string]interface{}{
 										"datadirectory": cfg.Reva.Storages.OwnCloud.Datadirectory,
+										"scan":          cfg.Reva.Storages.OwnCloud.Scan,
+										"autocreate":    cfg.Reva.Storages.OwnCloud.Autocreate,
+										"redis":         cfg.Reva.Storages.OwnCloud.Redis,
 									},
 									"s3": map[string]interface{}{
 										"region":     cfg.Reva.Storages.S3.Region,

--- a/pkg/command/storageroot.go
+++ b/pkg/command/storageroot.go
@@ -113,6 +113,9 @@ func StorageRoot(cfg *config.Config) *cli.Command {
 									},
 									"owncloud": map[string]interface{}{
 										"datadirectory": cfg.Reva.Storages.OwnCloud.Datadirectory,
+										"scan":          cfg.Reva.Storages.OwnCloud.Scan,
+										"autocreate":    cfg.Reva.Storages.OwnCloud.Autocreate,
+										"redis":         cfg.Reva.Storages.OwnCloud.Redis,
 									},
 									"s3": map[string]interface{}{
 										"region":     cfg.Reva.Storages.S3.Region,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,17 +72,17 @@ type StoragePort struct {
 	TempFolder string
 }
 
-// StorageConfig combines all available storage configuration parts.
+// StorageConfig combines all available storage driver configuration parts.
 type StorageConfig struct {
-	EOS      StorageEOS
-	Local    StorageLocal
-	OwnCloud StorageOwnCloud
-	S3       StorageS3
+	EOS      DriverEOS
+	Local    DriverLocal
+	OwnCloud DriverOwnCloud
+	S3       DriverS3
 	// TODO checksums ... figure out what that is supposed to do
 }
 
-// StorageEOS defines the available EOS storage configuration.
-type StorageEOS struct {
+// DriverEOS defines the available EOS driver configuration.
+type DriverEOS struct {
 	// Namespace for metadata operations
 	Namespace string
 
@@ -130,18 +130,21 @@ type StorageEOS struct {
 	SingleUsername string
 }
 
-// StorageLocal defines the available local storage configuration.
-type StorageLocal struct {
+// DriverLocal defines the available local storage driver configuration.
+type DriverLocal struct {
 	Root string
 }
 
-// StorageOwnCloud defines the available ownCloud storage configuration.
-type StorageOwnCloud struct {
+// DriverOwnCloud defines the available ownCloud storage driver configuration.
+type DriverOwnCloud struct {
 	Datadirectory string
+	Scan          bool
+	Autocreate    bool
+	Redis         string
 }
 
-// StorageS3 defines the available S3 storage configuration.
-type StorageS3 struct {
+// DriverS3 defines the available S3 storage driver configuration.
+type DriverS3 struct {
 	Region    string
 	AccessKey string
 	SecretKey string

--- a/pkg/flagset/storagehome.go
+++ b/pkg/flagset/storagehome.go
@@ -283,5 +283,26 @@ func StorageHomeWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_DATADIR"},
 			Destination: &cfg.Reva.Storages.OwnCloud.Datadirectory,
 		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-scan",
+			Value:       true,
+			Usage:       "scan files on startup to add fileids",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_SCAN"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Scan,
+		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-autocreate",
+			Value:       true,
+			Usage:       "autocreate home path for new users",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_AUTOCREATE"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Autocreate,
+		},
+		&cli.StringFlag{
+			Name:        "storage-owncloud-redis",
+			Value:       ":6379",
+			Usage:       "the address of the redis server",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_REDIS_ADDR"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Redis,
+		},
 	}
 }

--- a/pkg/flagset/storagehomedata.go
+++ b/pkg/flagset/storagehomedata.go
@@ -255,6 +255,27 @@ func StorageHomeDataWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_DATADIR"},
 			Destination: &cfg.Reva.Storages.OwnCloud.Datadirectory,
 		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-scan",
+			Value:       true,
+			Usage:       "scan files on startup to add fileids",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_SCAN"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Scan,
+		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-autocreate",
+			Value:       true,
+			Usage:       "autocreate home path for new users",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_AUTOCREATE"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Autocreate,
+		},
+		&cli.StringFlag{
+			Name:        "storage-owncloud-redis",
+			Value:       ":6379",
+			Usage:       "the address of the redis server",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_REDIS_ADDR"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Redis,
+		},
 
 		// Gateway
 

--- a/pkg/flagset/storageoc.go
+++ b/pkg/flagset/storageoc.go
@@ -283,5 +283,26 @@ func StorageOCWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_DATADIR"},
 			Destination: &cfg.Reva.Storages.OwnCloud.Datadirectory,
 		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-scan",
+			Value:       true,
+			Usage:       "scan files on startup to add fileids",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_SCAN"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Scan,
+		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-autocreate",
+			Value:       true,
+			Usage:       "autocreate home path for new users",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_AUTOCREATE"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Autocreate,
+		},
+		&cli.StringFlag{
+			Name:        "storage-owncloud-redis",
+			Value:       ":6379",
+			Usage:       "the address of the redis server",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_REDIS_ADDR"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Redis,
+		},
 	}
 }

--- a/pkg/flagset/storageocdata.go
+++ b/pkg/flagset/storageocdata.go
@@ -255,6 +255,27 @@ func StorageOCDataWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_DATADIR"},
 			Destination: &cfg.Reva.Storages.OwnCloud.Datadirectory,
 		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-scan",
+			Value:       true,
+			Usage:       "scan files on startup to add fileids",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_SCAN"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Scan,
+		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-autocreate",
+			Value:       true,
+			Usage:       "autocreate home path for new users",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_AUTOCREATE"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Autocreate,
+		},
+		&cli.StringFlag{
+			Name:        "storage-owncloud-redis",
+			Value:       ":6379",
+			Usage:       "the address of the redis server",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_REDIS_ADDR"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Redis,
+		},
 
 		// Gateway
 

--- a/pkg/flagset/storageroot.go
+++ b/pkg/flagset/storageroot.go
@@ -283,5 +283,26 @@ func StorageRootWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_DATADIR"},
 			Destination: &cfg.Reva.Storages.OwnCloud.Datadirectory,
 		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-scan",
+			Value:       true,
+			Usage:       "scan files on startup to add fileids",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_SCAN"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Scan,
+		},
+		&cli.BoolFlag{
+			Name:        "storage-owncloud-autocreate",
+			Value:       true,
+			Usage:       "autocreate home path for new users",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_AUTOCREATE"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Autocreate,
+		},
+		&cli.StringFlag{
+			Name:        "storage-owncloud-redis",
+			Value:       ":6379",
+			Usage:       "the address of the redis server",
+			EnvVars:     []string{"REVA_STORAGE_OWNCLOUD_REDIS_ADDR"},
+			Destination: &cfg.Reva.Storages.OwnCloud.Redis,
+		},
 	}
 }


### PR DESCRIPTION
Enhancement: expose owncloud storage driver config in flagset

Three new flags are now available:

- scan files on startup to generate missing fileids
  default: `true`
  env var: `REVA_STORAGE_OWNCLOUD_SCAN`
  cli option: `--storage-owncloud-scan`

- autocreate home path for new users
  default: `true`
  env var: `REVA_STORAGE_OWNCLOUD_AUTOCREATE`
  cli option: `--storage-owncloud-autocreate`

- the address of the redis server
  default: `:6379`
  env var: `REVA_STORAGE_OWNCLOUD_REDIS_ADDR`
  cli option: `--storage-owncloud-redis`

fixes https://github.com/owncloud/ocis-reva/issues/87
