### PR TITLE
storage providers now default to exposing data servers

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -133,8 +133,6 @@ def testing(ctx):
         'detach': True,
         'environment' : {
           'REVA_USERS_DRIVER': 'ldap',
-          'REVA_STORAGE_HOME_EXPOSE_DATA_SERVER': 1,
-          'REVA_STORAGE_OC_EXPOSE_DATA_SERVER': 1,
           'REVA_LDAP_HOSTNAME': 'ldap',
           'REVA_STORAGE_HOME_DATA_TEMP_FOLDER': '/srv/app/tmp/',
           'REVA_STORAGE_LOCAL_ROOT': '/srv/app/tmp/reva/root',

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ bin/ocis-reva auth-basic & \
 bin/ocis-reva auth-bearer & \
 bin/ocis-reva sharing & \
 bin/ocis-reva storage-root & \
-REVA_STORAGE_HOME_EXPOSE_DATA_SERVER=1 bin/ocis-reva storage-home & \
+bin/ocis-reva storage-home & \
 bin/ocis-reva storage-home-data & \
-REVA_STORAGE_OC_EXPOSE_DATA_SERVER=1 bin/ocis-reva storage-oc & \
+bin/ocis-reva storage-oc & \
 bin/ocis-reva storage-oc-data
 ```
 
@@ -90,9 +90,9 @@ For details on the `json` and `ldap` backends see the [documentation](https://ow
     bin/ocis-reva auth-bearer & \
     bin/ocis-reva sharing & \
     bin/ocis-reva storage-root & \
-    REVA_STORAGE_HOME_EXPOSE_DATA_SERVER=1 bin/ocis-reva storage-home & \
+    bin/ocis-reva storage-home & \
     bin/ocis-reva storage-home-data & \
-    REVA_STORAGE_OC_EXPOSE_DATA_SERVER=1 bin/ocis-reva storage-oc & \
+    bin/ocis-reva storage-oc & \
     bin/ocis-reva storage-oc-data & \
     bin/ocis-reva frontend
     ```

--- a/changelog/unreleased/issue-89.md
+++ b/changelog/unreleased/issue-89.md
@@ -1,0 +1,8 @@
+Change: storage providers now default to exposing data servers
+
+The flags that let reva storage providers announce that they expose a data server now defaults to true:
+
+`REVA_STORAGE_HOME_EXPOSE_DATA_SERVER=1`
+`REVA_STORAGE_OC_EXPOSE_DATA_SERVER=1`
+
+https://github.com/owncloud/ocis-reva/issues/89

--- a/pkg/flagset/storagehome.go
+++ b/pkg/flagset/storagehome.go
@@ -160,6 +160,7 @@ func StorageHomeWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "expose-data-server",
+			Value:       true,
 			Usage:       "exposes a dedicated data server",
 			EnvVars:     []string{"REVA_STORAGE_HOME_EXPOSE_DATA_SERVER"},
 			Destination: &cfg.Reva.StorageHome.ExposeDataServer,

--- a/pkg/flagset/storageoc.go
+++ b/pkg/flagset/storageoc.go
@@ -160,6 +160,7 @@ func StorageOCWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "expose-data-server",
+			Value:       true,
 			Usage:       "exposes a dedicated data server",
 			EnvVars:     []string{"REVA_STORAGE_OC_EXPOSE_DATA_SERVER"},
 			Destination: &cfg.Reva.StorageOC.ExposeDataServer,


### PR DESCRIPTION
The flags that let reva storage providers announce that they expose a data server now defaults to true:

`REVA_STORAGE_HOME_EXPOSE_DATA_SERVER=1`
`REVA_STORAGE_OC_EXPOSE_DATA_SERVER=1`

fixes https://github.com/owncloud/ocis-reva/issues/89