### PR TITLE
allow configuring user sharing driver, default to json

### DIFF
--- a/changelog/unreleased/user-sharing-driver-json.md
+++ b/changelog/unreleased/user-sharing-driver-json.md
@@ -1,0 +1,5 @@
+Enhancement: Allow configuring user sharing driver
+
+We now default to `json` which persists shares in the sharing manager in a json file instead of an in memory db.
+
+https://github.com/owncloud/ocis-reva/pull/115

--- a/pkg/command/sharing.go
+++ b/pkg/command/sharing.go
@@ -84,10 +84,10 @@ func Sharing(cfg *config.Config) *cli.Command {
 						// TODO build services dynamically
 						"services": map[string]interface{}{
 							"usershareprovider": map[string]interface{}{
-								"driver": "memory",
+								"driver": cfg.Reva.Sharing.UserDriver,
 							},
 							"publicshareprovider": map[string]interface{}{
-								"driver": "memory",
+								"driver": cfg.Reva.Sharing.PublicDriver,
 							},
 						},
 					},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,13 @@ type Gateway struct {
 	DisableHomeCreationOnLogin bool
 }
 
+// Sharing defines the available sharing configuration.
+type Sharing struct {
+	Port
+	UserDriver   string
+	PublicDriver string
+}
+
 // Port defines the available port configuration.
 type Port struct {
 	// MaxCPUs can be a number or a percentage
@@ -212,7 +219,7 @@ type Reva struct {
 	Users             Users
 	AuthBasic         Port
 	AuthBearer        Port
-	Sharing           Port
+	Sharing           Sharing
 	StorageRoot       StoragePort
 	StorageHome       StoragePort
 	StorageHomeData   StoragePort

--- a/pkg/flagset/sharing.go
+++ b/pkg/flagset/sharing.go
@@ -120,5 +120,19 @@ func SharingWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:   "--service usershareprovider [--service publicshareprovider]",
 			EnvVars: []string{"REVA_SHARING_SERVICES"},
 		},
+		&cli.StringFlag{
+			Name:        "user-driver",
+			Value:       "json",
+			Usage:       "driver to use for the UserShareProvider",
+			EnvVars:     []string{"REVA_SHARING_USER_DRIVER"},
+			Destination: &cfg.Reva.Sharing.UserDriver,
+		},
+		&cli.StringFlag{
+			Name:        "public-driver",
+			Value:       "memory",
+			Usage:       "driver to use for the PublicShareProvider",
+			EnvVars:     []string{"REVA_SHARING_PUBLIC_DRIVER"},
+			Destination: &cfg.Reva.Sharing.PublicDriver,
+		},
 	}
 }


### PR DESCRIPTION
We now default to `json` which persists shares in the sharing manager in a json file instead of an in memory db.