### PR TITLE
[Tests-only] delete test documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,64 +67,6 @@ richard:superfluidity
 
 For details on the `json` and `ldap` backends see the [documentation](https://owncloud.github.io/ocis-reva/#users)
 
-## Run oC10 API acceptance tests
-1.  start an LDAP server e.g. with docker:
-    ```
-    docker run --hostname ldap.my-company.com \
-        -e LDAP_TLS_VERIFY_CLIENT=never \
-        -e LDAP_DOMAIN=owncloud.com \
-        -e LDAP_ORGANISATION=ownCloud \
-        -e LDAP_ADMIN_PASSWORD=admin \
-        --name docker-slapd \
-        -p 127.0.0.1:389:389 \
-        -p 636:636 -d osixia/openldap
-    ```
-2.  start a Redis server e.g. with docker:
-    `docker run -e REDIS_DATABASES=1 -p 6379:6379 -d webhippie/redis:latest`
-
-3.  clone oC10 code: `git clone https://github.com/owncloud/core.git`
-
-4.  start reva with `REVA_USERS_DRIVER=ldap`:
-    ```
-    bin/ocis-reva gateway & \
-    REVA_USERS_DRIVER=ldap bin/ocis-reva users & \
-    REVA_USERS_DRIVER=ldap bin/ocis-reva auth-basic & \
-    bin/ocis-reva auth-bearer & \
-    bin/ocis-reva sharing & \
-    bin/ocis-reva storage-root & \
-    bin/ocis-reva storage-home & \
-    bin/ocis-reva storage-home-data & \
-    bin/ocis-reva storage-oc & \
-    bin/ocis-reva storage-oc-data & \
-    bin/ocis-reva frontend
-    ```
-
-5.  from inside the oC10 repo run the tests:
-    ```
-    make test-acceptance-api \
-        TEST_SERVER_URL=http://localhost:9140 \
-        TEST_EXTERNAL_USER_BACKENDS=true \
-        TEST_OCIS=true \
-        OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
-        BEHAT_FILTER_TAGS='~@skipOnOcis&&@TestAlsoOnExternalUserBackend&&~@skipOnLDAP'
-    ```
-
-    Make sure to adjust the settings `TEST_SERVER_URL` and `OCIS_REVA_DATA_ROOT` according to your environment
-
-    This will run all tests that can work with LDAP and are not skipped on OCIS
-    To run a subset of tests, e.g. a single suite, file or tag have a look at the [acceptance tests documentation](https://doc.owncloud.com/server/10.0/developer_manual/core/acceptance-tests.html#running-acceptance-tests-for-a-suite).
-    E.g. you can run all tests that are marked with a specific issue:
-    ```
-    make test-acceptance-api \
-        TEST_SERVER_URL=http://localhost:9140 \
-        TEST_EXTERNAL_USER_BACKENDS=true \
-        TEST_OCIS=true \
-        OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
-        BEHAT_FILTER_TAGS='@TestAlsoOnExternalUserBackend&&~@skipOnLDAP&&@issue-ocis-reva-46'
-    ```
-
-    Note that the `~@skipOnOcis` tag is removed here, because to fix an issue you want also to run the tests that are skipped in the CI run
-
 ## Security
 
 If you find a security issue please contact security@owncloud.com first.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ geekdocFilePath: testing.md
 
 ## Acceptance tests
 
-We are using the ownCloud 10 acceptance testsuite against ocis. To set this up you need the owncloud 10 core repo, an ldap server that the acceptance tests can use to manage users and the ocis-reva code.
+We are using the ownCloud 10 acceptance testsuite against ocis. To set this up you need the owncloud 10 core repo, a ldap server that the acceptance tests can use to manage users, a redis server for file-versions and the ocis-reva code.
 
 ### Getting the tests
 
@@ -19,7 +19,7 @@ All you need to do to get the acceptance tests is check out the core repo:
 git clone https://github.com/owncloud/core.git
 ```
 
-### Run an ldap server in a docker container
+### Run a ldap server in a docker container
 
 The ownCloud 10 acceptance tests will need write permission. You can start a suitable ldap server in a docker container with:
 
@@ -33,6 +33,11 @@ docker run --hostname ldap.my-company.com \
     -p 127.0.0.1:389:389 \
     -p 636:636 -d osixia/openldap
 ```
+### Run a redis server in a docker container
+
+File versions need a redis server. Start one with docker by using:
+
+`docker run -e REDIS_DATABASES=1 -p 6379:6379 -d webhippie/redis:latest`
 
 ### Run ocis-reva with that ldap server
 


### PR DESCRIPTION
1. a redis server is needed for the tests

2. the documentation of tests was moved to https://github.com/owncloud/ocis-reva/blob/master/docs/testing.md in #113 
so  no need to have it also in the README