### PR TITLE
Don't advertise unsupported chunking v2

### DIFF
--- a/pkg/command/frontend.go
+++ b/pkg/command/frontend.go
@@ -144,9 +144,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 											"undelete":          true,
 											"versioning":        true,
 										},
-										"dav": map[string]interface{}{
-											"chunking": "1.0",
-										},
+										"dav": map[string]interface{}{},
 										"files_sharing": map[string]interface{}{
 											"api_enabled":                       true,
 											"resharing":                         true,


### PR DESCRIPTION
Removed "chunking" attribute in the DAV capabilities.
Please note that chunking v2 is advertised as "chunking 1.0" while
chunking v1 is the attribute "bigfilechunking" which is already false.

@butonic as discussed