### PR TITLE
Update reva to v0.1.1-0.20200512135421

### DIFF
--- a/changelog/unreleased/update-reva-to-20200507093219.md
+++ b/changelog/unreleased/update-reva-to-20200507093219.md
@@ -1,6 +1,11 @@
-Enhancement: update reva to v0.1.1-0.20200507093219
+Enhancement: update reva to v0.1.1-0.20200512135421
 
-- Update reva to v0.1.1-0.20200507093219 (#161, #180)
+- Update reva to v0.1.1-0.20200507093219 (#161, #180, #192)
+- Fixed regression when uploading empty files to OCFS or EOS with PUT and TUS (#188, reva/#734)
+- On delete move the file versions to the trashbin (#94, reva/#731)
+- Fix OCFS move operation (#182, reva/#729)
+- Fix OCFS custom property / xattr removal (reva/#728)
+- Retry trashbin in case of timestamp collision (reva/#730)
 - Disable chunking v1 by default (reva/#678)
 - Implement ocs to http status code mapping (#26, reva/#696, reva/#707, reva/#711)
 - Handle the case if directory already exists (reva/#695)
@@ -14,6 +19,7 @@ Enhancement: update reva to v0.1.1-0.20200507093219
 
 https://github.com/owncloud/ocis-reva/pull/161
 https://github.com/owncloud/ocis-reva/pull/180
+https://github.com/owncloud/ocis-reva/pull/192
 https://github.com/cs3org/reva/pull/678
 https://github.com/owncloud/ocis-reva/issues/26
 https://github.com/cs3org/reva/pull/696
@@ -29,4 +35,13 @@ https://github.com/cs3org/reva/pull/713
 https://github.com/owncloud/ocis-reva/issues/57
 https://github.com/cs3org/reva/pull/720
 https://github.com/cs3org/reva/pull/718
+https://github.com/owncloud/ocis-reva/issue/94
+https://github.com/cs3org/reva/pull/731
+https://github.com/owncloud/ocis-reva/issue/188
+https://github.com/cs3org/reva/pull/734
+https://github.com/owncloud/ocis-reva/issue/182
+https://github.com/cs3org/reva/pull/729
+https://github.com/cs3org/reva/pull/728
+https://github.com/cs3org/reva/pull/730
+
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/cs3org/reva v0.1.1-0.20200507093219-c853e65a5c10
+	github.com/cs3org/reva v0.1.1-0.20200512135421-3aa67e818a8d
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/aws/aws-sdk-go v1.30.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.30.21 h1:19EO1Jr80+jLwJyITzH8c79C/6EwY5mMyasqDbBiCuc=
 github.com/aws/aws-sdk-go v1.30.21/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.30.22/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.30.25/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -156,6 +157,8 @@ github.com/cs3org/reva v0.1.1-0.20200506094053-4da63dd518a5 h1:hvrRJsQ89TP7y1Yq+
 github.com/cs3org/reva v0.1.1-0.20200506094053-4da63dd518a5/go.mod h1:BOxqZjt8eyD0S+w5yXXAPhqJptno3f3HmslCL7/CacI=
 github.com/cs3org/reva v0.1.1-0.20200507093219-c853e65a5c10 h1:hSwIn8HT6Y0HW7eOAR5XXvo+169bYyK+fQ+8StNjz8k=
 github.com/cs3org/reva v0.1.1-0.20200507093219-c853e65a5c10/go.mod h1:8CEZ2Vg0IQQEF/4rHe4l1KYsNYB9TehC79l5cFdY/zo=
+github.com/cs3org/reva v0.1.1-0.20200512135421-3aa67e818a8d h1:lDNY2AnYNY2RLlKebaeHBsqfepXvg8k5ntYvEZ/zjxA=
+github.com/cs3org/reva v0.1.1-0.20200512135421-3aa67e818a8d/go.mod h1:YIgUciBl5fg6xhV+ZPWkfWlc5H4wjXg/8+ngIYPzvKI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Mostly to unblock https://github.com/owncloud/ocis/pull/259 but also brings a few more interesting fixes