### PR TITLE
[Tests-only] Prove tests of core/37419

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -101,7 +101,7 @@ def apiTests(ctx):
          },
          'commands': [
            'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/tmp/testing',
-           'git clone -b master --depth=1 https://github.com/owncloud/core.git /srv/app/testrunner',
+           'git clone -b update-ocis-tests-litmus --depth=1 https://github.com/owncloud/core.git /srv/app/testrunner',
            'cd /srv/app/testrunner',
            'make test-acceptance-api'
           ],


### PR DESCRIPTION
Prove that OCIS tests of https://github.com/owncloud/core/pull/37419 still
pass with unskipping

