### PR TITLE
Make global TUS capability configurable

### DIFF
--- a/changelog/unreleased/add-tus-global-capabilities.md
+++ b/changelog/unreleased/add-tus-global-capabilities.md
@@ -1,0 +1,9 @@
+Enhancement: Add TUS global capability
+
+The TUS global capabilities from Reva are now exposed.
+
+The advertised max chunk size can be configured using the "--upload-max-chunk-size" CLI switch or "REVA_FRONTEND_UPLOAD_MAX_CHUNK_SIZE" environment variable.
+The advertised http method override can be configured using the "--upload-http-method-override" CLI switch or "REVA_FRONTEND_UPLOAD_HTTP_METHOD_OVERRIDE" environment variable.
+
+https://github.com/owncloud/ocis-reva/issues/177
+https://github.com/owncloud/ocis-reva/pull/228

--- a/pkg/command/frontend.go
+++ b/pkg/command/frontend.go
@@ -143,6 +143,13 @@ func Frontend(cfg *config.Config) *cli.Command {
 											"blacklisted_files": []string{},
 											"undelete":          true,
 											"versioning":        true,
+											"tus_support": map[string]interface{}{
+												"version":              "1.0.0",
+												"resumable":            "1.0.0",
+												"extension":            "creation,creation-with-upload",
+												"http_method_override": cfg.Reva.UploadHttpMethodOverride,
+												"max_chunk_size":       int(cfg.Reva.UploadMaxChunkSize),
+											},
 										},
 										"dav": map[string]interface{}{},
 										"files_sharing": map[string]interface{}{

--- a/pkg/command/frontend.go
+++ b/pkg/command/frontend.go
@@ -78,6 +78,24 @@ func Frontend(cfg *config.Config) *cli.Command {
 					desktopRedirectURIs[port] = fmt.Sprintf("http://localhost:%d", (port + 1024))
 				}
 
+				filesCfg := map[string]interface{}{
+					"private_links":     false,
+					"bigfilechunking":   false,
+					"blacklisted_files": []string{},
+					"undelete":          true,
+					"versioning":        true,
+				}
+
+				if !cfg.Reva.UploadDisableTus {
+					filesCfg["tus_support"] = map[string]interface{}{
+						"version":              "1.0.0",
+						"resumable":            "1.0.0",
+						"extension":            "creation,creation-with-upload",
+						"http_method_override": cfg.Reva.UploadHTTPMethodOverride,
+						"max_chunk_size":       int(cfg.Reva.UploadMaxChunkSize),
+					}
+				}
+
 				rcfg := map[string]interface{}{
 					"core": map[string]interface{}{
 						"max_cpus":             cfg.Reva.Users.MaxCPUs,
@@ -108,6 +126,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 								"chunk_folder":     "/var/tmp/reva/chunks",
 								"files_namespace":  cfg.Reva.OCDav.DavFilesNamespace,
 								"webdav_namespace": cfg.Reva.OCDav.WebdavNamespace,
+								"disable_tus":      cfg.Reva.UploadDisableTus,
 							},
 							"ocs": map[string]interface{}{
 								"config": map[string]interface{}{
@@ -117,6 +136,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 									"contact": "admin@localhost",
 									"ssl":     "false",
 								},
+								"disable_tus": cfg.Reva.UploadDisableTus,
 								"capabilities": map[string]interface{}{
 									"capabilities": map[string]interface{}{
 										"core": map[string]interface{}{
@@ -137,21 +157,8 @@ func Frontend(cfg *config.Config) *cli.Command {
 											"supported_types":       []string{"SHA256"},
 											"preferred_upload_type": "SHA256",
 										},
-										"files": map[string]interface{}{
-											"private_links":     false,
-											"bigfilechunking":   false,
-											"blacklisted_files": []string{},
-											"undelete":          true,
-											"versioning":        true,
-											"tus_support": map[string]interface{}{
-												"version":              "1.0.0",
-												"resumable":            "1.0.0",
-												"extension":            "creation,creation-with-upload",
-												"http_method_override": cfg.Reva.UploadHttpMethodOverride,
-												"max_chunk_size":       int(cfg.Reva.UploadMaxChunkSize),
-											},
-										},
-										"dav": map[string]interface{}{},
+										"files": filesCfg,
+										"dav":   map[string]interface{}{},
 										"files_sharing": map[string]interface{}{
 											"api_enabled":                       true,
 											"resharing":                         true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -253,6 +253,9 @@ type Reva struct {
 	// Configs can be used to configure the reva instance.
 	// Services and Ports will be ignored if this is used
 	Configs map[string]interface{}
+	// chunking and resumable upload config (TUS)
+	UploadMaxChunkSize       int
+	UploadHttpMethodOverride string
 }
 
 // Tracing defines the available tracing configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,7 +255,8 @@ type Reva struct {
 	Configs map[string]interface{}
 	// chunking and resumable upload config (TUS)
 	UploadMaxChunkSize       int
-	UploadHttpMethodOverride string
+	UploadHTTPMethodOverride string
+	UploadDisableTus         bool
 }
 
 // Tracing defines the available tracing configuration.

--- a/pkg/flagset/frontend.go
+++ b/pkg/flagset/frontend.go
@@ -159,6 +159,13 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 		},
 
 		// Chunking
+		&cli.BoolFlag{
+			Name:        "upload-disable-tus",
+			Value:       false,
+			Usage:       "Tells clients to not use TUS by disabling the capability (this doesn't disable the endpoints)",
+			EnvVars:     []string{"REVA_FRONTEND_UPLOAD_DISABLE_TUS"},
+			Destination: &cfg.Reva.UploadDisableTus,
+		},
 		&cli.IntFlag{
 			Name:        "upload-max-chunk-size",
 			Value:       0,
@@ -171,7 +178,7 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			Value:       "",
 			Usage:       "Specify an HTTP method (ex: POST) to use when uploading in case OPTIONS and PATCH are not available",
 			EnvVars:     []string{"REVA_FRONTEND_UPLOAD_HTTP_METHOD_OVERRIDE"},
-			Destination: &cfg.Reva.UploadHttpMethodOverride,
+			Destination: &cfg.Reva.UploadHTTPMethodOverride,
 		},
 	}
 }

--- a/pkg/flagset/frontend.go
+++ b/pkg/flagset/frontend.go
@@ -157,5 +157,21 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_GATEWAY_URL"},
 			Destination: &cfg.Reva.Gateway.URL,
 		},
+
+		// Chunking
+		&cli.IntFlag{
+			Name:        "upload-max-chunk-size",
+			Value:       0,
+			Usage:       "Max chunk size in bytes to advertise to clients through capabilities",
+			EnvVars:     []string{"REVA_FRONTEND_UPLOAD_MAX_CHUNK_SIZE"},
+			Destination: &cfg.Reva.UploadMaxChunkSize,
+		},
+		&cli.StringFlag{
+			Name:        "upload-http-method-override",
+			Value:       "",
+			Usage:       "Specify an HTTP method (ex: POST) to use when uploading in case OPTIONS and PATCH are not available",
+			EnvVars:     []string{"REVA_FRONTEND_UPLOAD_HTTP_METHOD_OVERRIDE"},
+			Destination: &cfg.Reva.UploadHttpMethodOverride,
+		},
 	}
 }


### PR DESCRIPTION
Added global TUS capability in the config structure.
Added config switches for the advertised max chunk size and http method
override.

- [ ] adjust value semantics for tus_support and max_chunk_size (see original ticket)
- [x] add config switch to disable "tus_support" completely
- [x] add changelog entry

Requires https://github.com/cs3org/reva/pull/775 to work.


