### PR TITLE
Update reva to v0.1.1-0.20200603071553-e05a87521618

### DIFF
--- a/changelog/unreleased/update-reva-to-20200603071553.md
+++ b/changelog/unreleased/update-reva-to-20200603071553.md
@@ -1,0 +1,12 @@
+Enhancement: update reva to v0.1.1-0.20200603071553-e05a87521618
+
+- Updated reva to v0.1.1-0.20200603071553-e05a87521618 (#244)
+- Add option to disable TUS on OC layer (#177, reva/#791)
+- Dataprovider now supports method override (#177, reva/#792)
+- OCS fixes for create public link (reva/#798)
+
+https://github.com/owncloud/ocis-reva/issues/244
+https://github.com/owncloud/ocis-reva/issues/177
+https://github.com/cs3org/reva/pull/791
+https://github.com/cs3org/reva/pull/792
+https://github.com/cs3org/reva/pull/798

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/cs3org/reva v0.1.1-0.20200529120551-4f2d9c85d3c9
+	github.com/cs3org/reva v0.1.1-0.20200603124923-9b9f2e5af0e9
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,10 @@ github.com/cs3org/reva v0.1.1-0.20200528123359-7d74bf8e9928 h1:6dIWlFuZNGz3tmK8I
 github.com/cs3org/reva v0.1.1-0.20200528123359-7d74bf8e9928/go.mod h1:ig/TuMCG/l6vjOvFkj/4tU27PBvcig+Kfjc4mF++BwQ=
 github.com/cs3org/reva v0.1.1-0.20200529120551-4f2d9c85d3c9 h1:j1jhTTKkXyRL4mZrfXn86poq8z3lRVV7N/KcuDVEudo=
 github.com/cs3org/reva v0.1.1-0.20200529120551-4f2d9c85d3c9/go.mod h1:FOU15UeWYXIckxEOwqjjoNAK/1EQrdRTuiX6x66b3Ts=
+github.com/cs3org/reva v0.1.1-0.20200603071553-e05a87521618 h1:W9qBdHKhY2PE5e//dWgHB/j3r8DDORImt0VvYZ7vtA0=
+github.com/cs3org/reva v0.1.1-0.20200603071553-e05a87521618/go.mod h1:FOU15UeWYXIckxEOwqjjoNAK/1EQrdRTuiX6x66b3Ts=
+github.com/cs3org/reva v0.1.1-0.20200603124923-9b9f2e5af0e9 h1:aYxzZ3anTavS2xyxEuPNFvUtbwmv0f+raWbRd/YE2yE=
+github.com/cs3org/reva v0.1.1-0.20200603124923-9b9f2e5af0e9/go.mod h1:FOU15UeWYXIckxEOwqjjoNAK/1EQrdRTuiX6x66b3Ts=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Brings in additions to TUS

