### PR TITLE
Update reva to v0.1.1-0.20200629094927-e33d65230abc

### DIFF
--- a/changelog/unreleased/update-reva-to-20200629.md
+++ b/changelog/unreleased/update-reva-to-20200629.md
@@ -1,0 +1,8 @@
+Enhancement: update reva to v0.1.1-0.20200629094927-e33d65230abc
+
+- Update reva to v0.1.1-0.20200629094927-e33d65230abc (#309)
+- Fix public link file share (#278, reva/#895)
+
+https://github.com/owncloud/ocis-reva/pull/309
+https://github.com/owncloud/ocis-reva/issues/278
+https://github.com/cs3org/reva/pull/895

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/owncloud/ocis-reva
 go 1.13
 
 require (
-	github.com/cs3org/reva v0.1.1-0.20200626111234-e21c32db9614
+	github.com/cs3org/reva v0.1.1-0.20200629094927-e33d65230abc
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ github.com/aws/aws-sdk-go v1.32.9 h1:ai+NZsCV+Z97+jqIKya49gbCObOay9FKww0/VCNuXug
 github.com/aws/aws-sdk-go v1.32.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.32.10 h1:cEJTxGcBGlsM2tN36MZQKhlK93O9HrnaRs+lq2f0zN8=
 github.com/aws/aws-sdk-go v1.32.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.32.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-xray-sdk-go v0.9.4/go.mod h1:XtMKdBQfpVut+tJEwI7+dJFRxxRdxHDyVNp2tHXRq04=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
@@ -194,6 +195,8 @@ github.com/cs3org/reva v0.1.1-0.20200626083045-8d345749ae0d h1:SCUMOhkYTEjFA7IsM
 github.com/cs3org/reva v0.1.1-0.20200626083045-8d345749ae0d/go.mod h1:wunIwvRI7Pd+QFB0YCK+jdAtq0udQzjt8iG7WQ+LLrs=
 github.com/cs3org/reva v0.1.1-0.20200626111234-e21c32db9614 h1:FAk15Sgy59cuPL9M7HEIq0/KX+hTJWFa013ALJHDKcQ=
 github.com/cs3org/reva v0.1.1-0.20200626111234-e21c32db9614/go.mod h1:wunIwvRI7Pd+QFB0YCK+jdAtq0udQzjt8iG7WQ+LLrs=
+github.com/cs3org/reva v0.1.1-0.20200629094927-e33d65230abc h1:AJuhNHmSHjkfDPvU3H2gu25UBUBxfWm0Ily+CJO2xe4=
+github.com/cs3org/reva v0.1.1-0.20200629094927-e33d65230abc/go.mod h1:aTjgnI4OFVK+1Ed6EtyDw5Q7Ujs9sSbY74d3I4Ph/xY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Brings in public link single file share

