### PR TITLE
Update reva to v0.1.1-0.20200630075923-39a90d431566

### DIFF
--- a/changelog/unreleased/update-reva-to-20200630.md
+++ b/changelog/unreleased/update-reva-to-20200630.md
@@ -1,0 +1,11 @@
+Enhancement: update reva to v0.1.1-0.20200630075923-39a90d431566
+
+- Update reva to v0.1.1-0.20200630075923-39a90d431566 (#320)
+- Return special value for public link password (#294, reva/#904)
+- Fix public stat and listcontainer response to contain the correct prefix (#310, reva/#902)
+
+https://github.com/owncloud/ocis-reva/pull/320
+https://github.com/owncloud/ocis-reva/issues/310
+https://github.com/cs3org/reva/pull/902
+https://github.com/owncloud/ocis-reva/issues/294
+https://github.com/cs3org/reva/pull/904

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/owncloud/ocis-reva
 go 1.13
 
 require (
-	github.com/cs3org/reva v0.1.1-0.20200629131207-04298ea1c088
+	github.com/cs3org/reva v0.1.1-0.20200630075923-39a90d431566
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14 h1:ORPIrxw/T33AL
 github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v0.1.1-0.20200629131207-04298ea1c088 h1:oCRNwQ4M1JoROK/jlYK1Cj1ElXky7ubFO8AA/YKMNfA=
 github.com/cs3org/reva v0.1.1-0.20200629131207-04298ea1c088/go.mod h1:aTjgnI4OFVK+1Ed6EtyDw5Q7Ujs9sSbY74d3I4Ph/xY=
+github.com/cs3org/reva v0.1.1-0.20200630075923-39a90d431566 h1:U70hDCk1IUY8i/lHMMdS18AyLLcicyn/G8LTHMvT/rE=
+github.com/cs3org/reva v0.1.1-0.20200630075923-39a90d431566/go.mod h1:aTjgnI4OFVK+1Ed6EtyDw5Q7Ujs9sSbY74d3I4Ph/xY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decker502/dnspod-go v0.2.0/go.mod h1:qsurYu1FgxcDwfSwXJdLt4kRsBLZeosEb9uq4Sy+08g=


### PR DESCRIPTION
Fixes for public link Webdav COPY and password field in response.

