### PR TITLE
[Tests-Only] Remove unneeded TestAlsoOnExternalUserBackend local_storage skipOnLDAP tags

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', '0dc76b2452ef0c4388af765a738679097bd1491d'),
+    apiTests(ctx, 'master', 'f7bf41b725b8dac55748c1a090c0d6b3617c89e5'),
   ]
 
   stages = [
@@ -97,7 +97,7 @@ def apiTests(ctx, coreBranch = 'master', coreCommit = ''):
         'pull': 'always',
         'environment' : {
           'TEST_SERVER_URL': 'http://reva-server:9140',
-          'BEHAT_FILTER_TAGS': '~@skipOnOcis&&~@skipOnOcis-OC-Storage&&~@skipOnLDAP&&@TestAlsoOnExternalUserBackend&&~@local_storage',
+          'BEHAT_FILTER_TAGS': '~@skipOnOcis&&~@skipOnOcis-OC-Storage',
           'REVA_LDAP_HOSTNAME':'ldap',
           'TEST_EXTERNAL_USER_BACKENDS':'true',
           'TEST_OCIS':'true',

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -82,7 +82,7 @@ TEST_SERVER_URL=http://localhost:9140 \
 TEST_EXTERNAL_USER_BACKENDS=true \
 TEST_OCIS=true \
 OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
-BEHAT_FILTER_TAGS='~@skipOnOcis&&~@skipOnLDAP&&@TestAlsoOnExternalUserBackend&&~@local_storage' \
+BEHAT_FILTER_TAGS='~@skipOnOcis' \
 SKELETON_DIR=apps/testing/data/apiSkeleton
 ```
 
@@ -111,7 +111,7 @@ If you want to work on a specific issue
     TEST_EXTERNAL_USER_BACKENDS=true \
     TEST_OCIS=true \
     OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
-    BEHAT_FILTER_TAGS='~@skipOnOcV10&&~@skipOnLDAP&&@TestAlsoOnExternalUserBackend&&~@local_storage&&@issue-ocis-reva-122'
+    BEHAT_FILTER_TAGS='~@skipOnOcV10&&@issue-ocis-reva-122'
     ```
 
     Note that the `~@skipOnOcis` tag is replaced by `~@skipOnOcV10` and the issue tag `@issue-ocis-reva-122` is added.


### PR DESCRIPTION
See core PR https://github.com/owncloud/core/pull/37616 - all these tags no longer need to be specified.
`skipOnOcis` is the important one.

PR #321 demonstrated that this will work.