### PR TITLE
Update reva to 20200701

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', 'f7bf41b725b8dac55748c1a090c0d6b3617c89e5'),
+    apiTests(ctx, 'master', 'a3cac3dad60348fc962d1d8743b202bc5f79596b'),
   ]
 
   stages = [

--- a/changelog/unreleased/update-reva-to-20200701.md
+++ b/changelog/unreleased/update-reva-to-20200701.md
@@ -1,0 +1,30 @@
+Enhancement: update reva to v0.1.1-0.20200701152626-2f6cc60e2f66
+
+- Update reva to v0.1.1-0.20200701152626-2f6cc60e2f66 (#328)
+- Use sync.Map on pool package (reva/#909)
+- Use mutex instead of sync.Map (reva/#915)
+- Use gatewayProviders instead of storageProviders on conn pool (reva/#916)
+- Add logic to ls and stat to process arbitrary metadata keys (reva/#905)
+- Preliminary implementation of Set/UnsetArbitraryMetadata (reva/#912)
+- Make datagateway forward headers (reva/#913, reva/#926)
+- Add option to cmd upload to disable tus (reva/#911)
+- OCS Share Allow date-only expiration for public shares (#288, reva/#918)
+- OCS Share Remove array from OCS Share update response (#252, reva/#919)
+- OCS Share Implement GET request for single shares  (#249, reva/#921)
+
+https://github.com/owncloud/ocis-reva/pull/328
+https://github.com/cs3org/reva/pull/909
+https://github.com/cs3org/reva/pull/915
+https://github.com/cs3org/reva/pull/916
+https://github.com/cs3org/reva/pull/905
+https://github.com/cs3org/reva/pull/912
+https://github.com/cs3org/reva/pull/913
+https://github.com/cs3org/reva/pull/926
+https://github.com/cs3org/reva/pull/911
+https://github.com/owncloud/ocis-reva/issues/288
+https://github.com/cs3org/reva/pull/918
+https://github.com/owncloud/ocis-reva/issues/252
+https://github.com/cs3org/reva/pull/919
+https://github.com/owncloud/ocis-reva/issues/249
+https://github.com/cs3org/reva/pull/921
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/owncloud/ocis-reva
 go 1.13
 
 require (
-	github.com/cs3org/reva v0.1.1-0.20200630075923-39a90d431566
+	github.com/cs3org/reva v0.1.1-0.20200701152626-2f6cc60e2f66
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,7 @@ github.com/aws/aws-sdk-go v1.32.10 h1:cEJTxGcBGlsM2tN36MZQKhlK93O9HrnaRs+lq2f0zN
 github.com/aws/aws-sdk-go v1.32.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.32.11 h1:1nYF+Tfccn/hnAZsuwPPMSCVUVnx3j6LKOpx/WhgH0A=
 github.com/aws/aws-sdk-go v1.32.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.32.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-xray-sdk-go v0.9.4/go.mod h1:XtMKdBQfpVut+tJEwI7+dJFRxxRdxHDyVNp2tHXRq04=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
@@ -163,6 +164,10 @@ github.com/cs3org/reva v0.1.1-0.20200629131207-04298ea1c088 h1:oCRNwQ4M1JoROK/jl
 github.com/cs3org/reva v0.1.1-0.20200629131207-04298ea1c088/go.mod h1:aTjgnI4OFVK+1Ed6EtyDw5Q7Ujs9sSbY74d3I4Ph/xY=
 github.com/cs3org/reva v0.1.1-0.20200630075923-39a90d431566 h1:U70hDCk1IUY8i/lHMMdS18AyLLcicyn/G8LTHMvT/rE=
 github.com/cs3org/reva v0.1.1-0.20200630075923-39a90d431566/go.mod h1:aTjgnI4OFVK+1Ed6EtyDw5Q7Ujs9sSbY74d3I4Ph/xY=
+github.com/cs3org/reva v0.1.1-0.20200701132325-5a4b59490469 h1:XcNOq0v1EM8GPb1tFa6vNq7NgQtJ49X01ku3T1JECyA=
+github.com/cs3org/reva v0.1.1-0.20200701132325-5a4b59490469/go.mod h1:umXd+gBuq0t1hiR8f+EplUxeWPcBnAIKPNKbXtA9EWU=
+github.com/cs3org/reva v0.1.1-0.20200701152626-2f6cc60e2f66 h1:0FEaqg/OF1wci6uVsn9VgU6BOrCYF9RUrOIzEXIfb6M=
+github.com/cs3org/reva v0.1.1-0.20200701152626-2f6cc60e2f66/go.mod h1:umXd+gBuq0t1hiR8f+EplUxeWPcBnAIKPNKbXtA9EWU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decker502/dnspod-go v0.2.0/go.mod h1:qsurYu1FgxcDwfSwXJdLt4kRsBLZeosEb9uq4Sy+08g=


### PR DESCRIPTION
For  https://github.com/owncloud/ocis-reva/issues/327

- [x] update again
- [x] fix for CI, https://github.com/owncloud/core/pull/37624
- [x] update CI commit to latest core master