### PR TITLE
Update reva to 20200709

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', 'ba243879dbda86c563f1e767791759fd6f5d97e1'),
+    apiTests(ctx, 'master', '3861d0ad74aebd474f9b6b64bd4e1d7d7081955e'),
   ]
 
   stages = [

--- a/changelog/unreleased/update-reva-to-20200709.md
+++ b/changelog/unreleased/update-reva-to-20200709.md
@@ -1,0 +1,32 @@
+Enhancement: update reva to v0.1.1-0.20200709064551-91eed007038f
+
+- Update reva to v0.1.1-0.20200709064551-91eed007038f (#362)
+- Fix config for uploads when data server is not exposed (reva/#936)
+- Update OCM partners endpoints (reva/#937)
+- Update Ailleron endpoint (reva/#938)
+- OCS: Fix initialization of shares json file (reva/#940)
+- OCS: Fix returned public link URL (#336, reva/#945)
+- OCS: Share wrap resource id correctly (#344, reva/#951)
+- OCS: Implement share handling for accepting and listing shares (#11, reva/#929)
+- ocm: dynamically lookup IPs for provider check (reva/#946)
+- ocm: add functionality to mail OCM invite tokens (reva/#944)
+- Change percentagused to percentageused (reva/#903)
+- Fix file-descriptor leak (reva/#954)
+
+https://github.com/owncloud/ocis-reva/pull/362
+https://github.com/cs3org/reva/pull/936
+https://github.com/cs3org/reva/pull/937
+https://github.com/cs3org/reva/pull/938
+https://github.com/cs3org/reva/pull/940
+https://github.com/cs3org/reva/pull/951
+https://github.com/owncloud/ocis-reva/issues/344
+https://github.com/cs3org/reva/pull/945
+https://github.com/owncloud/ocis-reva/issues/336
+https://github.com/cs3org/reva/pull/929
+https://github.com/owncloud/ocis-reva/issues/11
+https://github.com/cs3org/reva/pull/946
+https://github.com/cs3org/reva/pull/944
+https://github.com/cs3org/reva/pull/903
+https://github.com/cs3org/reva/pull/954
+
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/owncloud/ocis-reva
 go 1.13
 
 require (
-	github.com/cs3org/reva v0.1.1-0.20200703120955-223eaed348f0
+	github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/cs3org/reva v0.1.1-0.20200701152626-2f6cc60e2f66 h1:0FEaqg/OF1wci6uVs
 github.com/cs3org/reva v0.1.1-0.20200701152626-2f6cc60e2f66/go.mod h1:umXd+gBuq0t1hiR8f+EplUxeWPcBnAIKPNKbXtA9EWU=
 github.com/cs3org/reva v0.1.1-0.20200703120955-223eaed348f0 h1:8mWapjYcOdfkJdM2agfiLlnIsMULxEVwHhezTqA+SJg=
 github.com/cs3org/reva v0.1.1-0.20200703120955-223eaed348f0/go.mod h1:VUBjQP8XCiWwFTPhE9P4I47k0NbdczQa2q6JsJN2PqY=
+github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f h1:wsQOmNJGqxiXC3uTYHy1IPi39lO+UKD1adu2V3+8YtE=
+github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f/go.mod h1:VUBjQP8XCiWwFTPhE9P4I47k0NbdczQa2q6JsJN2PqY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decker502/dnspod-go v0.2.0/go.mod h1:qsurYu1FgxcDwfSwXJdLt4kRsBLZeosEb9uq4Sy+08g=


### PR DESCRIPTION
Also update the test commit

Brings in a bunch of sharing fixes and file id leak fix.