### PR TITLE
make frontend prefixes configurable

### DIFF
--- a/changelog/unreleased/make-frontend-prefixes-configurable.md
+++ b/changelog/unreleased/make-frontend-prefixes-configurable.md
@@ -1,0 +1,14 @@
+Enhancement: make frontend prefixes configurable
+
+We introduce three new environment variables and preconfigure them the following way:
+
+```
+REVA_FRONTEND_DATAGATEWAY_PREFIX="data"
+REVA_FRONTEND_OCDAV_PREFIX=""
+REVA_FRONTEND_OCS_PREFIX="ocs"
+```
+
+This restores the reva defaults that were changed upstream.
+
+https://github.com/owncloud/ocis-reva/pull/363
+https://github.com/cs3org/reva/pull/936/files#diff-51bf4fb310f7362f5c4306581132fc3bR63

--- a/pkg/command/frontend.go
+++ b/pkg/command/frontend.go
@@ -120,12 +120,13 @@ func Frontend(cfg *config.Config) *cli.Command {
 						// TODO build services dynamically
 						"services": map[string]interface{}{
 							"datagateway": map[string]interface{}{
+								"prefix":                 cfg.Reva.Frontend.DatagatewayPrefix,
 								"transfer_shared_secret": cfg.Reva.TransferSecret,
 								"timeout":                86400,
 								"insecure":               true,
 							},
 							"ocdav": map[string]interface{}{
-								"prefix":           "",
+								"prefix":           cfg.Reva.Frontend.OCDavPrefix,
 								"chunk_folder":     "/var/tmp/reva/chunks",
 								"files_namespace":  cfg.Reva.OCDav.DavFilesNamespace,
 								"webdav_namespace": cfg.Reva.OCDav.WebdavNamespace,
@@ -134,6 +135,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 								"disable_tus":      cfg.Reva.UploadDisableTus,
 							},
 							"ocs": map[string]interface{}{
+								"prefix": cfg.Reva.Frontend.OCSPrefix,
 								"config": map[string]interface{}{
 									"version": "1.8",
 									"website": "reva",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,15 @@ type Users struct {
 	JSON   string
 }
 
+// FrontendPort defines the available frontend configuration.
+type FrontendPort struct {
+	Port
+
+	DatagatewayPrefix string
+	OCDavPrefix       string
+	OCSPrefix         string
+}
+
 // StoragePort defines the available storage configuration.
 type StoragePort struct {
 	Port
@@ -230,7 +239,7 @@ type Reva struct {
 	OCDav           OCDav
 	Storages        StorageConfig
 	// Ports are used to configure which services to start on which port
-	Frontend          Port
+	Frontend          FrontendPort
 	DataGateway       Port
 	Gateway           Gateway
 	Users             Users

--- a/pkg/flagset/frontend.go
+++ b/pkg/flagset/frontend.go
@@ -166,7 +166,7 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			Value:       "ocs",
 			Usage:       "open collaboration services endpoint prefix",
 			EnvVars:     []string{"REVA_FRONTEND_OCS_PREFIX"},
-			Destination: &cfg.Reva.Frontend.OCDavPrefix,
+			Destination: &cfg.Reva.Frontend.OCSPrefix,
 		},
 
 		// Gateway

--- a/pkg/flagset/frontend.go
+++ b/pkg/flagset/frontend.go
@@ -147,6 +147,27 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:   "--service ocdav [--service ocs]",
 			EnvVars: []string{"REVA_FRONTEND_SERVICES"},
 		},
+		&cli.StringFlag{
+			Name:        "datagateway-prefix",
+			Value:       "data",
+			Usage:       "datagateway prefix",
+			EnvVars:     []string{"REVA_FRONTEND_DATAGATEWAY_PREFIX"},
+			Destination: &cfg.Reva.Frontend.DatagatewayPrefix,
+		},
+		&cli.StringFlag{
+			Name:        "ocdav-prefix",
+			Value:       "",
+			Usage:       "owncloud webdav endpoint prefix",
+			EnvVars:     []string{"REVA_FRONTEND_OCDAV_PREFIX"},
+			Destination: &cfg.Reva.Frontend.OCDavPrefix,
+		},
+		&cli.StringFlag{
+			Name:        "ocs-prefix",
+			Value:       "ocs",
+			Usage:       "open collaboration services endpoint prefix",
+			EnvVars:     []string{"REVA_FRONTEND_OCS_PREFIX"},
+			Destination: &cfg.Reva.Frontend.OCDavPrefix,
+		},
 
 		// Gateway
 


### PR DESCRIPTION
We introduce three new environment variables and preconfigure them the following way:

```
REVA_FRONTEND_DATAGATEWAY_PREFIX="data"
REVA_FRONTEND_OCDAV_PREFIX=""
REVA_FRONTEND_OCS_PREFIX="ocs"
```

This restores the reva defaults that were changed upstream.

https://github.com/cs3org/reva/pull/936/files#diff-51bf4fb310f7362f5c4306581132fc3bR63