### PR TITLE
[Tests-Only] Bump core commit for tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', '3861d0ad74aebd474f9b6b64bd4e1d7d7081955e'),
+    apiTests(ctx, 'master', 'eafeb8f4189b017aa151e0be642c1725e5ccac62'),
   ]
 
   stages = [


### PR DESCRIPTION
To the latest core commit (same commit as https://github.com/cs3org/reva/pull/960 ) so we are running the same set of scenarios in the API tests.