### PR TITLE
Update reva to 20200710

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', 'eafeb8f4189b017aa151e0be642c1725e5ccac62'),
+    apiTests(ctx, 'master', '73023ed1e0009dc25a68d4cfd3ddf11b9c33d115'),
   ]
 
   stages = [

--- a/changelog/unreleased/update-reva-to-20200710.md
+++ b/changelog/unreleased/update-reva-to-20200710.md
@@ -1,0 +1,14 @@
+Enhancement: update reva to v0.1.1-0.20200710143425-cf38a45220c5
+
+- Update reva to v0.1.1-0.20200710143425-cf38a45220c5 (#371)
+- Add wopi open (reva/#920)
+- Added a CS3API compliant data exporter to Mentix (reva/#955)
+- Read SMTP password from env if not set in config (reva/#953)
+- OCS share fix including file info after update (reva/#958)
+- Add flag to smtpclient for for unauthenticated SMTP (reva/#963)
+
+https://github.com/cs3org/reva/pull/920
+https://github.com/cs3org/reva/pull/953
+https://github.com/cs3org/reva/pull/955
+https://github.com/cs3org/reva/pull/958
+https://github.com/cs3org/reva/pull/963

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/owncloud/ocis-reva
 go 1.13
 
 require (
-	github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f
+	github.com/cs3org/reva v0.1.1-0.20200710143425-cf38a45220c5
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,10 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSY
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cs3org/cato v0.0.0-20200618163134-e83dd323b17e/go.mod h1:6GOQIYvO+ZepxBKY9geuIAF7qfozDeDsTrX0BW9LZ0k=
+github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14 h1:ORPIrxw/T33ALlpaon9IMRzf54ArJQWCYlcECZiRmEc=
 github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v0.1.1-0.20200629131207-04298ea1c088 h1:oCRNwQ4M1JoROK/jlYK1Cj1ElXky7ubFO8AA/YKMNfA=
 github.com/cs3org/reva v0.1.1-0.20200629131207-04298ea1c088/go.mod h1:aTjgnI4OFVK+1Ed6EtyDw5Q7Ujs9sSbY74d3I4Ph/xY=
 github.com/cs3org/reva v0.1.1-0.20200630075923-39a90d431566 h1:U70hDCk1IUY8i/lHMMdS18AyLLcicyn/G8LTHMvT/rE=
@@ -173,6 +175,8 @@ github.com/cs3org/reva v0.1.1-0.20200703120955-223eaed348f0 h1:8mWapjYcOdfkJdM2a
 github.com/cs3org/reva v0.1.1-0.20200703120955-223eaed348f0/go.mod h1:VUBjQP8XCiWwFTPhE9P4I47k0NbdczQa2q6JsJN2PqY=
 github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f h1:wsQOmNJGqxiXC3uTYHy1IPi39lO+UKD1adu2V3+8YtE=
 github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f/go.mod h1:VUBjQP8XCiWwFTPhE9P4I47k0NbdczQa2q6JsJN2PqY=
+github.com/cs3org/reva v0.1.1-0.20200710143425-cf38a45220c5 h1:buENUkKNviU7c3/+E19GTY2Vk+KpSHbXUeWJQsNbpCE=
+github.com/cs3org/reva v0.1.1-0.20200710143425-cf38a45220c5/go.mod h1:V/SuCrkQ+Mz7EOs4gAHgl6Bq9JmpWy0beVIfE3fGGX8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decker502/dnspod-go v0.2.0/go.mod h1:qsurYu1FgxcDwfSwXJdLt4kRsBLZeosEb9uq4Sy+08g=


### PR DESCRIPTION
Brings in the reva items in the changelog. 

This will include new test code and scenario changes matching https://github.com/cs3org/reva/pull/966 from:
https://github.com/owncloud/core/pull/37674 Remove admin auth error in log when running API acceptance tests
https://github.com/owncloud/core/pull/37675 Add env var TEST_REVA

Which allows the latest core test scenarios to pass here.

```
64 scenarios (464 passed)
3359 steps (3359 passed)
6m5.92s (20.40Mb)
```
https://cloud.drone.io/owncloud/ocis-reva/662/2/6