### PR TITLE
[Tests-Only] Update owncloud/core commit id for oC10APIAcceptanceTests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', '73023ed1e0009dc25a68d4cfd3ddf11b9c33d115'),
+    apiTests(ctx, 'master', '9db442250583d3b71e633cf77fbcf643ed67e994'),
   ]
 
   stages = [


### PR DESCRIPTION
This brings the core commit used for API  tests up-to-date the same as https://github.com/cs3org/reva/pull/989