### PR TITLE
update reva for url signing

### DIFF
--- a/changelog/unreleased/update-reva-to-20200722.md
+++ b/changelog/unreleased/update-reva-to-20200722.md
@@ -1,0 +1,13 @@
+Enhancement: update reva to v0.1.1-0.20200722125752-6dea7936f9d1
+
+- Update reva to v0.1.1-0.20200722125752-6dea7936f9d1
+- Added signing key capability (reva/#986)
+- Add functionality to create webdav references for OCM shares (reva/#974)
+- Added a site locations exporter to Mentix (reva/#972)
+- Add option to config to allow requests to hosts with unverified certificates (reva/#969)
+
+https://github.com/owncloud/ocis-reva/pull/392
+https://github.com/cs3org/reva/pull/986
+https://github.com/cs3org/reva/pull/974
+https://github.com/cs3org/reva/pull/972
+https://github.com/cs3org/reva/pull/969

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/owncloud/ocis-reva
 go 1.13
 
 require (
-	github.com/cs3org/reva v0.1.1-0.20200710143425-cf38a45220c5
+	github.com/cs3org/reva v0.1.1-0.20200722125752-6dea7936f9d1
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/haya14busa/goverage v0.0.0-20180129164344-eec3514a20b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,7 @@ github.com/aws/aws-sdk-go v1.32.11 h1:1nYF+Tfccn/hnAZsuwPPMSCVUVnx3j6LKOpx/WhgH0
 github.com/aws/aws-sdk-go v1.32.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.32.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.1/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.33.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-xray-sdk-go v0.9.4/go.mod h1:XtMKdBQfpVut+tJEwI7+dJFRxxRdxHDyVNp2tHXRq04=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
@@ -177,6 +178,10 @@ github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f h1:wsQOmNJGqxiXC3uTY
 github.com/cs3org/reva v0.1.1-0.20200709064551-91eed007038f/go.mod h1:VUBjQP8XCiWwFTPhE9P4I47k0NbdczQa2q6JsJN2PqY=
 github.com/cs3org/reva v0.1.1-0.20200710143425-cf38a45220c5 h1:buENUkKNviU7c3/+E19GTY2Vk+KpSHbXUeWJQsNbpCE=
 github.com/cs3org/reva v0.1.1-0.20200710143425-cf38a45220c5/go.mod h1:V/SuCrkQ+Mz7EOs4gAHgl6Bq9JmpWy0beVIfE3fGGX8=
+github.com/cs3org/reva v0.1.1-0.20200722082002-1e57c4994e26 h1:F4Rq8kRwXvaQHDlSbgH1QTTDo54rmDuKOuMWf7ywVe8=
+github.com/cs3org/reva v0.1.1-0.20200722082002-1e57c4994e26/go.mod h1:yPtGZIud+QVWLN7lxPwZLNj2/BCx3xu2DNUcTJE1Mkk=
+github.com/cs3org/reva v0.1.1-0.20200722125752-6dea7936f9d1 h1:f/XZNSkCpS0ndLzMq/IRA0k2P1B/04Qvgf7s4qtQoGQ=
+github.com/cs3org/reva v0.1.1-0.20200722125752-6dea7936f9d1/go.mod h1:yPtGZIud+QVWLN7lxPwZLNj2/BCx3xu2DNUcTJE1Mkk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decker502/dnspod-go v0.2.0/go.mod h1:qsurYu1FgxcDwfSwXJdLt4kRsBLZeosEb9uq4Sy+08g=

--- a/pkg/command/frontend.go
+++ b/pkg/command/frontend.go
@@ -159,6 +159,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 												"productname":    "reva",
 												"hostname":       "",
 											},
+											"support_url_signing": true,
 										},
 										"checksums": map[string]interface{}{
 											"supported_types":       []string{"SHA256"},


### PR DESCRIPTION
part of https://github.com/owncloud/ocis-proxy/pull/75

this PR currently hardcodes the new signing support capability as true. making them configurable is tracked in https://github.com/owncloud/ocis-reva/issues/227