### PR TITLE
[Tests-Only] Bump commit for oC10APIAcceptanceTests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', '378d38ab844e048bc88ca7cc365592017f0c7227'),
+    apiTests(ctx, 'master', '24b305a38f259584b683256880eb9e42f99f19c5'),
   ]
 
   stages = [


### PR DESCRIPTION
Includes these oC10APIAcceptanceTests changes from recent days:
https://github.com/owncloud/core/pull/37745 Include trailing slash when matching a suite name
https://github.com/owncloud/core/pull/37746 Refactor listFolder acceptance tests
https://github.com/owncloud/core/pull/37749 use usersHaveBeenCreated & delete UserHelper::createUser
https://github.com/owncloud/core/pull/37751 Add tests for new capabilities
https://github.com/owncloud/core/pull/37752 Skip new lock tests on old ownCloud

Bumps to the same commit id like https://github.com/cs3org/reva/pull/1030