### PR TITLE
[Tests-Only] Bump core commit id for API acceptance tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', 'b4e4e2e76bcd1770412602113882256bec5444b8'),
+    apiTests(ctx, 'master', '7f1c384e8027b17f89427a1dd430ab273c15c7ef'),
   ]
 
   stages = [


### PR DESCRIPTION
Gets us these core acceptance test changes:

https://github.com/owncloud/core/pull/37753 only send userid and password on user creation
https://github.com/owncloud/core/pull/37756 Delete users after test ocis ocs