### PR TITLE
[Tests-Only] Bump core commit id for core PR 37753

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   before = [
     testing(ctx),
-    apiTests(ctx, 'master', '24b305a38f259584b683256880eb9e42f99f19c5'),
+    apiTests(ctx, 'master', 'b4e4e2e76bcd1770412602113882256bec5444b8'),
   ]
 
   stages = [


### PR DESCRIPTION
Gets us these core acceptance test changes:

https://github.com/owncloud/core/pull/37753 only send userid and password on user creation