### PR TITLE
[Tests-Only] Refactor .drone.star API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 config = {
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': 'a06b1bd5ba8e5244bfaf7fa04f441961e6fb0daa',
+    'coreCommit': '9416491281aa5315b630e02e3c7e8ca76689505a',
     'numberOfParts': 2
   }
 }

--- a/.drone.star
+++ b/.drone.star
@@ -1,5 +1,13 @@
+config = {
+  'apiTests': {
+    'coreBranch': 'master',
+    'coreCommit': 'a06b1bd5ba8e5244bfaf7fa04f441961e6fb0daa',
+    'numberOfParts': 2
+  }
+}
+
 def main(ctx):
-  before = testPipelines(ctx, 'master', 'a06b1bd5ba8e5244bfaf7fa04f441961e6fb0daa')
+  before = testPipelines(ctx)
 
   stages = [
     docker(ctx, 'amd64'),
@@ -20,111 +28,41 @@ def main(ctx):
 
   return before + stages + after
 
-def testPipelines(ctx, coreBranch = 'master', coreCommit = ''):
-  return [
+def testPipelines(ctx):
+  pipelines = [
     testing(ctx),
-    localApiTests(ctx, coreBranch, coreCommit),
-    coreApiTests(ctx, coreBranch, coreCommit, 1, 2),
-    coreApiTests(ctx, coreBranch, coreCommit, 2, 2),
+    localApiTests(ctx, config['apiTests']['coreBranch'], config['apiTests']['coreCommit'])
   ]
+
+  for runPart in range(1, config['apiTests']['numberOfParts'] + 1):
+    pipelines.append(coreApiTests(ctx, config['apiTests']['coreBranch'], config['apiTests']['coreCommit'], runPart, config['apiTests']['numberOfParts']))
+
+  return pipelines
 
 def localApiTests(ctx, coreBranch = 'master', coreCommit = ''):
   return {
     'kind': 'pipeline',
     'type': 'docker',
-    'name': 'Local-API-Tests',
+    'name': 'localApiTests',
     'platform': {
       'os': 'linux',
       'arch': 'amd64',
     },
-    'steps': [
+    'steps':
+      build() +
+      revaServer() +
+      cloneCoreRepos(coreBranch, coreCommit) + [
       {
-        'name': 'build',
-        'image': 'webhippie/golang:1.13',
-        'pull': 'always',
-        'commands': [
-          'make build',
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ],
-      },
-      {
-        'name': 'reva-server',
-        'image': 'webhippie/golang:1.13',
-        'pull': 'always',
-        'detach': True,
-        'environment' : {
-          'REVA_LDAP_HOSTNAME': 'ldap',
-          'REVA_LDAP_PORT': 636,
-          'REVA_LDAP_BIND_DN': 'cn=admin,dc=owncloud,dc=com',
-          'REVA_LDAP_BIND_PASSWORD': 'admin',
-          'REVA_LDAP_BASE_DN': 'dc=owncloud,dc=com',
-          'REVA_LDAP_SCHEMA_UID': 'uid',
-          'REVA_STORAGE_HOME_DATA_TEMP_FOLDER': '/srv/app/tmp/',
-          'REVA_STORAGE_OWNCLOUD_DATADIR': '/srv/app/tmp/reva/data',
-          'REVA_STORAGE_OC_DATA_TEMP_FOLDER': '/srv/app/tmp/',
-          'REVA_STORAGE_OC_DATA_SERVER_URL': 'http://reva-server:9164/data',
-          'REVA_STORAGE_OC_DATA_URL': 'reva-server:9164',
-          'REVA_STORAGE_OWNCLOUD_REDIS_ADDR': 'redis:6379',
-          'REVA_SHARING_USER_JSON_FILE': '/srv/app/tmp/reva/shares.json',
-          'REVA_FRONTEND_URL': 'http://reva-server:9140',
-          'REVA_DATAGATEWAY_URL': 'http://reva-server:9140/data',
-        },
-        'commands': [
-          'apk add mailcap',
-          'mkdir -p /srv/app/tmp/reva',
-          'bin/ocis-reva --log-level debug --log-pretty gateway &',
-          'bin/ocis-reva --log-level debug --log-pretty users &',
-          'bin/ocis-reva --log-level debug --log-pretty auth-basic &',
-          'bin/ocis-reva --log-level debug --log-pretty auth-bearer &',
-          'bin/ocis-reva --log-level debug --log-pretty sharing &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-home &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-home-data &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-oc &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-oc-data &',
-          'bin/ocis-reva --log-level debug --log-pretty frontend &',
-          'bin/ocis-reva --log-level debug --log-pretty reva-storage-public-link'
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ]
-      },
-      {
-        'name': 'clone-test-repos',
-        'image': 'owncloudci/php:7.2',
-        'pull': 'always',
-        'commands': [
-          'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/tmp/testing',
-          'git clone -b %s --single-branch --no-tags https://github.com/owncloud/core.git /srv/app/testrunner' % (coreBranch),
-          'cd /srv/app/testrunner',
-		] + ([
-          'git checkout %s' % (coreCommit)
-		] if coreCommit != '' else []),
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ]
-      },
-      {
-        'name': 'local-acceptance-tests',
+        'name': 'LocalApiTests',
         'image': 'owncloudci/php:7.2',
         'pull': 'always',
         'environment' : {
           'TEST_SERVER_URL': 'http://reva-server:9140',
-          'REVA_LDAP_HOSTNAME':'ldap',
-          'TEST_EXTERNAL_USER_BACKENDS':'true',
-          'TEST_OCIS':'true',
           'OCIS_REVA_DATA_ROOT': '/srv/app/tmp/reva/',
           'SKELETON_DIR': '/srv/app/tmp/testing/data/apiSkeleton',
+          'TEST_EXTERNAL_USER_BACKENDS':'true',
+          'REVA_LDAP_HOSTNAME':'ldap',
+          'TEST_OCIS':'true',
           'PATH_TO_CORE': '/srv/app/testrunner'
         },
         'commands': [
@@ -138,27 +76,9 @@ def localApiTests(ctx, coreBranch = 'master', coreCommit = ''):
         ]
       },
     ],
-    'services': [
-      {
-        'name': 'ldap',
-        'image': 'osixia/openldap',
-        'pull': 'always',
-        'environment': {
-          'LDAP_DOMAIN': 'owncloud.com',
-          'LDAP_ORGANISATION': 'owncloud',
-          'LDAP_ADMIN_PASSWORD': 'admin',
-          'LDAP_TLS_VERIFY_CLIENT': 'never',
-         },
-      },
-      {
-        'name': 'redis',
-        'image': 'webhippie/redis',
-        'pull': 'always',
-        'environment': {
-          'REDIS_DATABASES': 1
-         },
-      },
-    ],
+    'services':
+      ldap() +
+      redis(),
     'volumes': [
       {
         'name': 'gopath',
@@ -183,95 +103,22 @@ def coreApiTests(ctx, coreBranch = 'master', coreCommit = '', part_number = 1, n
       'os': 'linux',
       'arch': 'amd64',
     },
-    'steps': [
+    'steps':
+      build() +
+      revaServer() +
+      cloneCoreRepos(coreBranch, coreCommit) + [
       {
-        'name': 'build',
-        'image': 'webhippie/golang:1.13',
-        'pull': 'always',
-        'commands': [
-          'make build',
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ],
-      },
-      {
-        'name': 'reva-server',
-        'image': 'webhippie/golang:1.13',
-        'pull': 'always',
-        'detach': True,
-        'environment' : {
-          'REVA_LDAP_HOSTNAME': 'ldap',
-          'REVA_LDAP_PORT': 636,
-          'REVA_LDAP_BIND_DN': 'cn=admin,dc=owncloud,dc=com',
-          'REVA_LDAP_BIND_PASSWORD': 'admin',
-          'REVA_LDAP_BASE_DN': 'dc=owncloud,dc=com',
-          'REVA_LDAP_SCHEMA_UID': 'uid',
-          'REVA_STORAGE_HOME_DATA_TEMP_FOLDER': '/srv/app/tmp/',
-          'REVA_STORAGE_OWNCLOUD_DATADIR': '/srv/app/tmp/reva/data',
-          'REVA_STORAGE_OC_DATA_TEMP_FOLDER': '/srv/app/tmp/',
-          'REVA_STORAGE_OC_DATA_SERVER_URL': 'http://reva-server:9164/data',
-          'REVA_STORAGE_OC_DATA_URL': 'reva-server:9164',
-          'REVA_STORAGE_OWNCLOUD_REDIS_ADDR': 'redis:6379',
-          'REVA_SHARING_USER_JSON_FILE': '/srv/app/tmp/reva/shares.json',
-          'REVA_FRONTEND_URL': 'http://reva-server:9140',
-          'REVA_DATAGATEWAY_URL': 'http://reva-server:9140/data',
-        },
-        'commands': [
-          'apk add mailcap',
-          'mkdir -p /srv/app/tmp/reva',
-          'bin/ocis-reva --log-level debug --log-pretty gateway &',
-          'bin/ocis-reva --log-level debug --log-pretty users &',
-          'bin/ocis-reva --log-level debug --log-pretty auth-basic &',
-          'bin/ocis-reva --log-level debug --log-pretty auth-bearer &',
-          'bin/ocis-reva --log-level debug --log-pretty sharing &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-home &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-home-data &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-oc &',
-          'bin/ocis-reva --log-level debug --log-pretty storage-oc-data &',
-          'bin/ocis-reva --log-level debug --log-pretty frontend &',
-          'bin/ocis-reva --log-level debug --log-pretty reva-storage-public-link'
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ]
-      },
-      {
-        'name': 'clone-test-repos',
-        'image': 'owncloudci/php:7.2',
-        'pull': 'always',
-        'commands': [
-          'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/tmp/testing',
-          'git clone -b %s --single-branch --no-tags https://github.com/owncloud/core.git /srv/app/testrunner' % (coreBranch),
-          'cd /srv/app/testrunner',
-		] + ([
-          'git checkout %s' % (coreCommit)
-		] if coreCommit != '' else []),
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ]
-      },
-      {
-        'name': 'core-acceptance-tests-%s' % (part_number),
+        'name': 'oC10ApiTests-%s' % (part_number),
         'image': 'owncloudci/php:7.2',
         'pull': 'always',
         'environment' : {
           'TEST_SERVER_URL': 'http://reva-server:9140',
-          'BEHAT_FILTER_TAGS': '~@notToImplementOnOCIS&&~@toImplementOnOCIS',
-          'REVA_LDAP_HOSTNAME':'ldap',
-          'TEST_EXTERNAL_USER_BACKENDS':'true',
-          'TEST_OCIS':'true',
           'OCIS_REVA_DATA_ROOT': '/srv/app/tmp/reva/',
           'SKELETON_DIR': '/srv/app/tmp/testing/data/apiSkeleton',
+          'TEST_EXTERNAL_USER_BACKENDS':'true',
+          'REVA_LDAP_HOSTNAME':'ldap',
+          'TEST_OCIS':'true',
+          'BEHAT_FILTER_TAGS': '~@notToImplementOnOCIS&&~@toImplementOnOCIS',
           'DIVIDE_INTO_NUM_PARTS': number_of_parts,
           'RUN_PART':  part_number,
           'EXPECTED_FAILURES_FILE': '/drone/src/tests/acceptance/expected-failures.txt'
@@ -288,27 +135,9 @@ def coreApiTests(ctx, coreBranch = 'master', coreCommit = '', part_number = 1, n
         ]
       },
     ],
-    'services': [
-      {
-        'name': 'ldap',
-        'image': 'osixia/openldap',
-        'pull': 'always',
-        'environment': {
-          'LDAP_DOMAIN': 'owncloud.com',
-          'LDAP_ORGANISATION': 'owncloud',
-          'LDAP_ADMIN_PASSWORD': 'admin',
-          'LDAP_TLS_VERIFY_CLIENT': 'never',
-         },
-      },
-      {
-        'name': 'redis',
-        'image': 'webhippie/redis',
-        'pull': 'always',
-        'environment': {
-          'REDIS_DATABASES': 1
-         },
-      },
-    ],
+    'services':
+      ldap() +
+      redis(),
     'volumes': [
       {
         'name': 'gopath',
@@ -1096,3 +925,116 @@ def website(ctx):
       ],
     },
   }
+
+def build():
+  return [
+    {
+      'name': 'build',
+      'image': 'webhippie/golang:1.13',
+      'pull': 'always',
+      'commands': [
+        'make build',
+      ],
+      'volumes': [
+        {
+          'name': 'gopath',
+          'path': '/srv/app',
+        }
+      ]
+    }
+  ]
+
+def revaServer():
+  return [
+    {
+      'name': 'reva-server',
+      'image': 'webhippie/golang:1.13',
+      'pull': 'always',
+      'detach': True,
+      'environment' : {
+        'REVA_LDAP_HOSTNAME': 'ldap',
+        'REVA_LDAP_PORT': 636,
+        'REVA_LDAP_BIND_DN': 'cn=admin,dc=owncloud,dc=com',
+        'REVA_LDAP_BIND_PASSWORD': 'admin',
+        'REVA_LDAP_BASE_DN': 'dc=owncloud,dc=com',
+        'REVA_LDAP_SCHEMA_UID': 'uid',
+        'REVA_STORAGE_HOME_DATA_TEMP_FOLDER': '/srv/app/tmp/',
+        'REVA_STORAGE_OWNCLOUD_DATADIR': '/srv/app/tmp/reva/data',
+        'REVA_STORAGE_OC_DATA_TEMP_FOLDER': '/srv/app/tmp/',
+        'REVA_STORAGE_OC_DATA_SERVER_URL': 'http://reva-server:9164/data',
+        'REVA_STORAGE_OC_DATA_URL': 'reva-server:9164',
+        'REVA_STORAGE_OWNCLOUD_REDIS_ADDR': 'redis:6379',
+        'REVA_SHARING_USER_JSON_FILE': '/srv/app/tmp/reva/shares.json',
+        'REVA_FRONTEND_URL': 'http://reva-server:9140',
+        'REVA_DATAGATEWAY_URL': 'http://reva-server:9140/data',
+      },
+      'commands': [
+        'apk add mailcap',
+        'mkdir -p /srv/app/tmp/reva',
+        'bin/ocis-reva --log-level debug --log-pretty gateway &',
+        'bin/ocis-reva --log-level debug --log-pretty users &',
+        'bin/ocis-reva --log-level debug --log-pretty auth-basic &',
+        'bin/ocis-reva --log-level debug --log-pretty auth-bearer &',
+        'bin/ocis-reva --log-level debug --log-pretty sharing &',
+        'bin/ocis-reva --log-level debug --log-pretty storage-home &',
+        'bin/ocis-reva --log-level debug --log-pretty storage-home-data &',
+        'bin/ocis-reva --log-level debug --log-pretty storage-oc &',
+        'bin/ocis-reva --log-level debug --log-pretty storage-oc-data &',
+        'bin/ocis-reva --log-level debug --log-pretty frontend &',
+        'bin/ocis-reva --log-level debug --log-pretty reva-storage-public-link'
+      ],
+      'volumes': [
+        {
+          'name': 'gopath',
+          'path': '/srv/app',
+        },
+      ]
+    }
+  ]
+
+def cloneCoreRepos(coreBranch, coreCommit):
+  return [
+    {
+      'name': 'clone-core-repos',
+      'image': 'owncloudci/php:7.2',
+      'pull': 'always',
+      'commands': [
+        'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/tmp/testing',
+        'git clone -b %s --single-branch --no-tags https://github.com/owncloud/core.git /srv/app/testrunner' % (coreBranch),
+        'cd /srv/app/testrunner',
+      ] + ([
+        'git checkout %s' % (coreCommit)
+      ] if coreCommit != '' else []),
+      'volumes': [{
+        'name': 'gopath',
+        'path': '/srv/app',
+      }]
+    }
+  ]
+
+def ldap():
+  return [
+    {
+      'name': 'ldap',
+      'image': 'osixia/openldap',
+      'pull': 'always',
+      'environment': {
+        'LDAP_DOMAIN': 'owncloud.com',
+        'LDAP_ORGANISATION': 'owncloud',
+        'LDAP_ADMIN_PASSWORD': 'admin',
+        'LDAP_TLS_VERIFY_CLIENT': 'never',
+      },
+    }
+  ]
+
+def redis():
+  return [
+    {
+      'name': 'redis',
+      'image': 'webhippie/redis',
+      'pull': 'always',
+      'environment': {
+        'REDIS_DATABASES': 1
+      },
+    }
+  ]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,9 +109,15 @@ Also, ocis behaves partly differently with EOS-Storage and OC-Storage. There are
 If you want to work on a specific issue
 
 1.  adjust the core commit id to the latest commit in core so that CI will run the latest test code and scenarios from core.
-    For that change this line in the `main` function:
+    For that change `coreCommit` in the `config` section:
 
-        apiTests(ctx, 'master', 'a06b1bd5ba8e5244bfaf7fa04f441961e6fb0daa')
+        config = {
+          'apiTests': {
+            'coreBranch': 'master',
+            'coreCommit': 'a06b1bd5ba8e5244bfaf7fa04f441961e6fb0daa',
+            'numberOfParts': 2
+          }
+        }
 
 2.  locally run each of the tests marked with that issue in the expected failures file:
 


### PR DESCRIPTION
1) reduce the duplicated code
2) put the API test parameters in a config section

This is like what is already done in OCIS. I made the code match what is in OCIS PR https://github.com/owncloud/ocis/pull/427 That should reduce future maintenance - the parameters are in a top `config` section and the acceptance-test code has the same functions and structure.
