### PR TITLE
[Tests-Only] Bump core commit for tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 config = {
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '9416491281aa5315b630e02e3c7e8ca76689505a',
+    'coreCommit': '1bee9ca8bc5ca37d3ceeb1f22f89ff8fb9690d83',
     'numberOfParts': 2
   }
 }


### PR DESCRIPTION
Gets us:
https://github.com/owncloud/core/pull/37767 Report the total scenarios that passed and failed across all suites
https://github.com/owncloud/core/pull/37769 Remove old skipOnOcV10.* tags

in CI