### PR TITLE
[Tests-Only] don't run preview tests in ocis-reva 

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -63,7 +63,7 @@ def localApiTestsOcStorage(ctx, coreBranch = 'master', coreCommit = ''):
           'TEST_EXTERNAL_USER_BACKENDS':'true',
           'REVA_LDAP_HOSTNAME':'ldap',
           'TEST_OCIS':'true',
-          'BEHAT_FILTER_TAGS': '~@skipOnOcis-OC-Storage',
+          'BEHAT_FILTER_TAGS': '~@skipOnOcis-OC-Storage&&~@preview-extension-required',
           'PATH_TO_CORE': '/srv/app/testrunner'
         },
         'commands': [

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -84,7 +84,7 @@ TEST_SERVER_URL=http://localhost:9140 \
 TEST_EXTERNAL_USER_BACKENDS=true \
 TEST_OCIS=true \
 OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
-BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS' \
+BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~@preview-extension-required' \
 SKELETON_DIR=apps/testing/data/apiSkeleton
 ```
 


### PR DESCRIPTION
### Description
Updated` drone.star` and `testing.md` file for tag preview-extension-required so that preview tests won't run in ocis-rev

### Related Issue
- Fixes https://github.com/owncloud/ocis-reva/issues/281
