### PR TITLE
[Tests-Only] Bump core commit 20200812

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 config = {
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '5e6593b9ed1124b815039c9efb943ba23d9e457c',
+    'coreCommit': 'aa87e9c07c5558387c37921d850e8d8e99d6cd45',
     'numberOfParts': 2
   }
 }

--- a/tests/acceptance/expected-failures.txt
+++ b/tests/acceptance/expected-failures.txt
@@ -799,11 +799,6 @@ apiWebdavProperties2/getFileProperties.feature:455
 apiWebdavUpload1/uploadFile.feature:112
 apiWebdavUpload1/uploadFile.feature:113
 #
-apiWebdavUpload1/uploadFile.feature:197
-apiWebdavUpload1/uploadFile.feature:198
-apiWebdavUpload1/uploadFile.feature:199
-apiWebdavUpload1/uploadFile.feature:200
-#
 # https://github.com/owncloud/ocis-reva/issues/56 remote.php/dav/uploads endpoint does not exist
 apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature:14
 apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature:31

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavPreviews-previews.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavPreviews-previews.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-187
+@api @issue-ocis-187
 Feature: previews of files downloaded through the webdav API
 
   Background:

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
@@ -19,7 +19,8 @@ Feature: upload file
       | old         | "file ?2.txt"       |
       | new         | "file ?2.txt"       |
 
-  @issue-product-127
+  @skipOnOcis-OC-Storage @issue-product-127
+  # this scenario passes/fails intermittently on OC storage, so do not run it in CI
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: uploading a file inside a folder changes its etag
     Given using <dav_version> DAV path


### PR DESCRIPTION
1) Remove an unused skipOnOcis tag from a local feature file
2) Skip intermittent upload etag local test scenario (it is no good running intermittent tests in CI)
3) Bump core commit id to get latest CI scripts including core PR https://github.com/owncloud/core/pull/37785