### PR TITLE
[Tests-Only] Bump core commit for tests 20200914

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 config = {
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': 'e9850b40657ff78f32cb5585ec00342fe07a5ff2',
+    'coreCommit': 'b3404863626519fc2aa758286385290abdf43d52',
     'numberOfParts': 4
   }
 }


### PR DESCRIPTION
Gets https://github.com/owncloud/core/pull/37882 "[Tests-Only] Add some more flexible provisioning API tests for getUsers"

Note: this is "not so interesting" here in `ocis-reva` - the provisioning API does not exist, and the tests are skipped anyway.