### PR TITLE
[Tests-Only] Bump core commit for tests 20200915

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 config = {
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': 'b3404863626519fc2aa758286385290abdf43d52',
+    'coreCommit': '39bcf3874f2e388bbe7a7802e2f1e3c6a4b8216a',
     'numberOfParts': 4
   }
 }


### PR DESCRIPTION
Gets us:
https://github.com/owncloud/core/pull/37913 [Tests-Only] Report HTTP status when file content is wrong

That helps to see the HTTP  status of a test when the downloaded file content is wrong.