### PR TITLE
Config for mapping home directory to different storage providers

### DIFF
--- a/changelog/unreleased/home-mapping.md
+++ b/changelog/unreleased/home-mapping.md
@@ -1,0 +1,9 @@
+Enhancement: Functionality to map home directory to different storage providers
+
+We added a parameter in reva that allows us to redirect /home requests to
+different storage providers based on a mapping derived from the user attributes,
+which was previously not possible since we hardcode the /home path for all
+users. This PR adds the config for that parameter.
+
+https://github.com/owncloud/ocis-reva/pull/480
+https://github.com/cs3org/reva/pull/1142

--- a/pkg/command/gateway.go
+++ b/pkg/command/gateway.go
@@ -111,6 +111,7 @@ func Gateway(cfg *config.Config) *cli.Command {
 								"datagateway":                    urlWithScheme(cfg.Reva.DataGateway.URL),
 								"transfer_shared_secret":         cfg.Reva.TransferSecret,
 								"transfer_expires":               cfg.Reva.TransferExpires,
+								"home_mapping":                   cfg.Reva.Gateway.HomeMapping,
 							},
 							"authregistry": map[string]interface{}{
 								"driver": "static",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,9 +20,10 @@ type Gateway struct {
 	Port
 	CommitShareToStorageGrant  bool
 	CommitShareToStorageRef    bool
+	DisableHomeCreationOnLogin bool
 	ShareFolder                string
 	LinkGrants                 string
-	DisableHomeCreationOnLogin bool
+	HomeMapping                string
 }
 
 // StorageRegistry defines the available storage registry configuration

--- a/pkg/flagset/gateway.go
+++ b/pkg/flagset/gateway.go
@@ -104,6 +104,13 @@ func GatewayWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"REVA_GATEWAY_DISABLE_HOME_CREATION_ON_LOGIN"},
 			Destination: &cfg.Reva.Gateway.DisableHomeCreationOnLogin,
 		},
+		&cli.StringFlag{
+			Name:        "storage-home-mapping",
+			Value:       "",
+			Usage:       "mapping template for user home paths to user-specific mount points",
+			EnvVars:     []string{"REVA_STORAGE_HOME_MAPPING"},
+			Destination: &cfg.Reva.Gateway.HomeMapping,
+		},
 
 		// other services
 


### PR DESCRIPTION
Functionality to map home directory to different storage providers

https://github.com/cs3org/reva/pull/1142 added a parameter in reva that allows us to redirect /home requests to different storage providers based on a mapping derived from the user attributes, which was previously not possible since we hardcode the /home path for all users. This PR adds the config for that parameter.